### PR TITLE
Tstesco/local api vllm streaming

### DIFF
--- a/lm_eval/loggers/evaluation_tracker.py
+++ b/lm_eval/loggers/evaluation_tracker.py
@@ -191,6 +191,7 @@ class EvaluationTracker:
         self,
         results: dict,
         samples: dict,
+        serialize_model_source: bool = False,
     ) -> None:
         """
         Saves the aggregated results and samples to the output path and pushes them to the Hugging Face hub if requested.
@@ -215,6 +216,9 @@ class EvaluationTracker:
                         ]
                         task_hashes[task_name] = hash_string("".join(sample_hashes))
 
+                if not serialize_model_source:
+                    # remove model_source to avoid serialization issues
+                    self.general_config_tracker.model_source = None
                 # update initial results dict
                 results.update({"task_hashes": task_hashes})
                 results.update(asdict(self.general_config_tracker))

--- a/lm_eval/loggers/utils.py
+++ b/lm_eval/loggers/utils.py
@@ -3,7 +3,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union, List
 
 import numpy as np
 from torch.utils.collect_env import get_pretty_env_info
@@ -35,7 +35,7 @@ def remove_none_pattern(input_string: str) -> Tuple[str, bool]:
     return result, removed
 
 
-def _handle_non_serializable(o: Any) -> Union[int, str, list]:
+def _handle_non_serializable(o: Any) -> Union[int, str, List]:
     """Handle non-serializable objects by converting them to serializable types.
 
     Args:

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -17,7 +17,7 @@ from typing import (
     Tuple,
     Union,
 )
-
+from collections import defaultdict
 
 try:
     import requests
@@ -389,7 +389,36 @@ class TemplateAPI(TemplateLM):
                     )
                 # raising exception will retry the request
                 response.raise_for_status()
-                outputs = await response.json()
+                # Handle vLLM streaming case: buffer response per choice
+                if payload.get('stream', False):
+                    choice_text = defaultdict(str)
+                    output = None
+                    async for chunk in response.content.iter_any():
+                        # Decode chunk from bytes to string
+                        chunk_data = chunk.decode("utf-8").strip()
+                        # Server-Sent Events (SSE) format starts with "data: "
+                        event_list = chunk_data[len("data: "):].split("\n\ndata: ")
+                        for event_str in event_list:
+                            if event_str == "[DONE]":
+                                # stop condition
+                                break
+                            try:
+                                # Convert the chunk data to JSON
+                                output = json.loads(event_str)
+                                for choice in output["choices"]:
+                                    choice_text[choice["index"]] += choice["text"]
+                            except json.JSONDecodeError as e:
+                                eval_logger.error(f"Failed to parse chunk data: {chunk_data}. Error: {e}")
+                                continue
+                    if output:
+                        # update the output with the concatenated text
+                        # assume that the other parameters did not change between chunks
+                        outputs = output
+                        for choice in output["choices"]:
+                            idx = choice["index"]
+                            outputs["choices"][idx]["text"] = choice_text[idx]
+                else:
+                    outputs = await response.json()
             answers = (
                 self.parse_generations(
                     outputs=outputs,

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 
 try:
     import requests
-    from aiohttp import ClientSession, TCPConnector
+    from aiohttp import ClientSession, TCPConnector, ClientTimeout
     from tenacity import RetryError, retry, stop_after_attempt, wait_exponential
     from tqdm import tqdm
     from tqdm.asyncio import tqdm_asyncio
@@ -376,11 +376,14 @@ class TemplateAPI(TemplateLM):
             **kwargs,
         )
         cache_method = "generate_until" if generate else "loglikelihood"
+        # increase default timeout for API requests
+        timeout_value = ClientTimeout(total=600)
         try:
             async with session.post(
                 self.base_url,
                 json=payload,
                 headers=self.header,
+                timeout=timeout_value,
             ) as response:
                 if not response.ok:
                     error_text = await response.text()

--- a/lm_eval/tasks/ifeval/instructions.py
+++ b/lm_eval/tasks/ifeval/instructions.py
@@ -483,7 +483,11 @@ class HighlightSectionChecker(Instruction):
             if highlight.strip("*").strip():
                 num_highlights += 1
         for highlight in double_highlights:
-            if highlight.removeprefix("**").removesuffix("**").strip():
+            if highlight.startswith("**"):
+                highlight = highlight[2:]
+            if highlight.endswith("**"):
+                highlight = highlight[:-2]
+            if highlight.strip():
                 num_highlights += 1
 
         return num_highlights >= self._num_highlights

--- a/lm_eval/tasks/ifeval/instructions.py
+++ b/lm_eval/tasks/ifeval/instructions.py
@@ -934,15 +934,23 @@ class JsonFormat(Instruction):
         return []
 
     def check_following(self, value):
-        value = (
-            value.strip()
-            .removeprefix("```json")
-            .removeprefix("```Json")
-            .removeprefix("```JSON")
-            .removeprefix("```")
-            .removesuffix("```")
-            .strip()
-        )
+        value = value.strip()
+
+        # Remove prefixes manually
+        if value.startswith("```json"):
+            value = value[len("```json"):]
+        elif value.startswith("```Json"):
+            value = value[len("```Json"):]
+        elif value.startswith("```JSON"):
+            value = value[len("```JSON"):]
+        elif value.startswith("```"):
+            value = value[len("```"):]
+
+        # Remove suffix manually
+        if value.endswith("```"):
+            value = value[:-len("```")]
+
+        value = value.strip()
         try:
             json.loads(value)
         except ValueError:

--- a/lm_eval/tasks/ifeval/utils.py
+++ b/lm_eval/tasks/ifeval/utils.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, List
 
 from lm_eval.tasks.ifeval import instructions_registry
 from lm_eval.utils import eval_logger
@@ -8,18 +8,18 @@ from lm_eval.utils import eval_logger
 @dataclasses.dataclass
 class InputExample:
     key: int
-    instruction_id_list: list[str]
+    instruction_id_list: List[str]
     prompt: str
-    kwargs: list[Dict[str, Optional[Union[str, int]]]]
+    kwargs: List[Dict[str, Optional[Union[str, int]]]]
 
 
 @dataclasses.dataclass
 class OutputExample:
-    instruction_id_list: list[str]
+    instruction_id_list: List[str]
     prompt: str
     response: str
     follow_all_instructions: bool
-    follow_instruction_list: list[bool]
+    follow_instruction_list: List[bool]
 
 
 def test_instruction_following_strict(


### PR DESCRIPTION
# change log

- add option serialize_model_source to not serial model source, this causes errors with unserializable types during logging
- Python 3.8 support: usage of `from typing import List`, removeprefix/removesuffix
- increase aiohttp timeout to 600 seconds for long prefill + decodes requests
- add support for streaming responses evaluation