### PR TITLE
Update latex2sympy2 to latex2sympy2_extended

### DIFF
--- a/lm_eval/tasks/r1_evals/utils.py
+++ b/lm_eval/tasks/r1_evals/utils.py
@@ -8,7 +8,7 @@ from sympy import N, simplify
 from sympy.parsing.latex import parse_latex
 from sympy.parsing.sympy_parser import parse_expr
 from word2number import w2n
-from latex2sympy2 import latex2sympy
+from latex2sympy2_extended import latex2sympy
 
 import re
 import regex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ testing = ["pytest", "pytest-cov", "pytest-xdist"]
 vllm = ["vllm>=0.4.2"]
 zeno = ["pandas", "zeno-client"]
 wandb = ["wandb>=0.16.3", "pandas", "numpy"]
-r1_evals = ["latex2sympy2"]
+r1_evals = ["latex2sympy2_extended[antlr4_11_0]"]
 all = [
     "lm_eval[anthropic]",
     "lm_eval[dev]",


### PR DESCRIPTION
### Issue: 
`r1_evals` just specifies `latex2sympy2` without any version constraint. However, `latex2sympy2` (version 1.9.1) was built with `ANTLR 4.7.2` and has hardcoded parser files that require exactly that version. This `latex2sympy2` package hasn't been updated since April of 2023 and has caused compatibility errors and has the potential to cause many more version compatibility errors. 

### Fix: 
The newer `latex2sympy2-extended` package supports multiple ANTLR versions including 4.11.0.