### PR TITLE
Fix LiveCodeBench Evaluation for datasets 4.0.0 Compatibility

### DIFF
--- a/lm_eval/tasks/livecodebench/livecodebench.yaml
+++ b/lm_eval/tasks/livecodebench/livecodebench.yaml
@@ -1,6 +1,7 @@
 task: livecodebench
 dataset_path: json
-data_files:
+dataset_kwargs:
+  data_files:
     test:
       - "hf://datasets/livecodebench/code_generation_lite/test.jsonl"
       - "hf://datasets/livecodebench/code_generation_lite/test2.jsonl"

--- a/lm_eval/tasks/livecodebench/livecodebench.yaml
+++ b/lm_eval/tasks/livecodebench/livecodebench.yaml
@@ -1,5 +1,5 @@
 task: livecodebench
-dataset_path: json
+dataset_path: livecodebench/code_generation_lite
 dataset_kwargs:
   data_files:
     test:

--- a/lm_eval/tasks/livecodebench/livecodebench.yaml
+++ b/lm_eval/tasks/livecodebench/livecodebench.yaml
@@ -1,7 +1,13 @@
 task: livecodebench
-dataset_path: livecodebench/code_generation_lite
-dataset_kwargs:
-  version_tag: "release_v6"
+dataset_path: json
+data_files:
+    test:
+      - "hf://datasets/livecodebench/code_generation_lite/test.jsonl"
+      - "hf://datasets/livecodebench/code_generation_lite/test2.jsonl"
+      - "hf://datasets/livecodebench/code_generation_lite/test3.jsonl"
+      - "hf://datasets/livecodebench/code_generation_lite/test4.jsonl"
+      - "hf://datasets/livecodebench/code_generation_lite/test5.jsonl"
+      - "hf://datasets/livecodebench/code_generation_lite/test6.jsonl"
 output_type: generate_until
 validation_split: test
 doc_to_text: !function utils.doc_to_text_with_format

--- a/lm_eval/tasks/livecodebench/livecodebench.yaml
+++ b/lm_eval/tasks/livecodebench/livecodebench.yaml
@@ -1,5 +1,5 @@
 task: livecodebench
-dataset_path: livecodebench/code_generation_lite
+dataset_path: json
 dataset_kwargs:
   data_files:
     test:


### PR DESCRIPTION
### Problem
The LiveCodeBench evaluation was failing when using datasets 4.0.0 due to the removal of script-based dataset loading support. The error occurred because:
- `datasets 4.0.0` removed support for dataset loading scripts
- LiveCodeBench (`livecodebench/code_generation_lite`) relied on a Python script (`code_generation_lite.py`) to download and process JSONL files
- The evaluation would fail with: RuntimeError: Dataset scripts are no longer supported, but found `code_generation_lite.py`

### Root Cause Analysis
The `livecodebench/code_generation_lite` dataset used a loading script that:
- Downloaded 6 JSONL files (`test.jsonl` through `test6.jsonl`)
- Selected files based on the `version_tag` parameter
- For release_v6: loaded all 6 files containing 1055 total examples
- Required `trust_remote_code=True` to execute the script

### Solution
Replaced script-based loading with direct file specification that achieves identical results:

#### Before (datasets 3.6.0 compatible):
```
dataset_path: livecodebench/code_generation_lite
dataset_kwargs:
  version_tag: "release_v6"
```

#### After (datasets 4.0.0 compatible):
```
dataset_path: json
dataset_kwargs:
  data_files:
    test:
      - "hf://datasets/livecodebench/code_generation_lite/test.jsonl"
      - "hf://datasets/livecodebench/code_generation_lite/test2.jsonl"
      - "hf://datasets/livecodebench/code_generation_lite/test3.jsonl"
      - "hf://datasets/livecodebench/code_generation_lite/test4.jsonl"
      - "hf://datasets/livecodebench/code_generation_lite/test5.jsonl"
      - "hf://datasets/livecodebench/code_generation_lite/test6.jsonl"
```

#### Key Changes
- Dataset Loading Method: Changed from script-based to direct file specification
- File Path: Updated dataset_path from `livecodebench/code_generation_lite` to `json`
- File Specification: Added explicit `data_files` list with all 6 JSONL files for `release_v6`
- Security: No longer requires `trust_remote_code=True`

