### PR TITLE
Fix UnboundLocalError by assigning a value for outputs_str before ref…

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -404,7 +404,8 @@ class TemplateAPI(TemplateLM):
             return answers
         # If the retries also fail
         except BaseException as e:
-            eval_logger.error(f"Exception:{repr(e)}, {outputs}, retrying.")
+            outputs_str = locals().get('outputs', 'undefined')
+            eval_logger.error(f"Exception:{repr(e)}, {outputs_str}, retrying.")
             raise e
         finally:
             if acquired:


### PR DESCRIPTION
### Issue 
Analyzing the Models CI run log (https://github.com/tenstorrent/tt-shield/actions/runs/17626471478/job/50087598610#step:9:2271), I have noticed the following happening: 
1. Some requests encountered network issues (normal under high load)
2. lm-evaluation-harness tried to retry these requests
3. The retry code crashed with UnboundLocalError: local variable 'outputs' referenced before assignment
4. This caused the entire evaluation to terminate, sending abort signals to all running requests
5. Server detected client disconnection and shut down gracefully

### Error Log 
```
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 407, in amodel_call
eval_logger.error(f"Exception:{repr(e)}, {outputs}, retrying.")
UnboundLocalError: local variable 'outputs' referenced before assignment

Requesting API:  99%|█████████▉| 1002/1008 [3:17:09<01:10, 11.81s/it]
2025-09-11:03:23:35,408 ERROR    [base_events.py:1758] Task exception was never retrieved
future: <Task finished name='Task-1386' coro=<tqdm_asyncio.gather.<locals>.wrap_awaitable() done, defined at /opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tqdm/asyncio.py:75> exception=UnboundLocalError("local variable 'outputs' referenced before assignment")>
Traceback (most recent call last):
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 376, in amodel_call
async with session.post(
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 1488, in __aenter__
self._resp: _RetType = await self._coro
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 770, in _request
resp = await handler(req)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 748, in _connect_and_send_request
await resp.start(conn)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 532, in start
message, payload = await protocol.read()  # type: ignore[union-attr]
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/streams.py", line 672, in read
await self._waiter
aiohttp.client_exceptions.ServerDisconnectedError: Server disconnected

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tqdm/asyncio.py", line 76, in wrap_awaitable
return i, await f
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
return await copy(fn, *args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
do = await self.iter(retry_state=retry_state)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
result = await action(retry_state)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/_utils.py", line 99, in inner
return call(*args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/__init__.py", line 420, in exc_check
raise retry_exc.reraise()
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/__init__.py", line 187, in reraise
raise self.last_attempt.result()
File "/home/ubuntu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/concurrent/futures/_base.py", line 451, in result
return self.__get_result()
File "/home/ubuntu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
raise self._exception
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
result = await fn(*args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 407, in amodel_call
eval_logger.error(f"Exception:{repr(e)}, {outputs}, retrying.")
UnboundLocalError: local variable 'outputs' referenced before assignment
2025-09-11:03:23:35,411 ERROR    [base_events.py:1758] Task exception was never retrieved
future: <Task finished name='Task-1681' coro=<tqdm_asyncio.gather.<locals>.wrap_awaitable() done, defined at /opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tqdm/asyncio.py:75> exception=UnboundLocalError("local variable 'outputs' referenced before assignment")>
Traceback (most recent call last):
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 376, in amodel_call
async with session.post(
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 1488, in __aenter__
self._resp: _RetType = await self._coro
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 770, in _request
resp = await handler(req)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 748, in _connect_and_send_request
await resp.start(conn)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 532, in start
message, payload = await protocol.read()  # type: ignore[union-attr]
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/streams.py", line 672, in read
await self._waiter
aiohttp.client_exceptions.ServerDisconnectedError: Server disconnected

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tqdm/asyncio.py", line 76, in wrap_awaitable
return i, await f
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
return await copy(fn, *args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
do = await self.iter(retry_state=retry_state)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
result = await action(retry_state)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/_utils.py", line 99, in inner
return call(*args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/__init__.py", line 420, in exc_check
raise retry_exc.reraise()
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/__init__.py", line 187, in reraise
raise self.last_attempt.result()
File "/home/ubuntu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/concurrent/futures/_base.py", line 451, in result
return self.__get_result()
File "/home/ubuntu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
raise self._exception
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
result = await fn(*args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 407, in amodel_call
eval_logger.error(f"Exception:{repr(e)}, {outputs}, retrying.")
UnboundLocalError: local variable 'outputs' referenced before assignment
2025-09-11:03:23:35,411 ERROR    [base_events.py:1758] Task exception was never retrieved
future: <Task finished name='Task-1434' coro=<tqdm_asyncio.gather.<locals>.wrap_awaitable() done, defined at /opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tqdm/asyncio.py:75> exception=UnboundLocalError("local variable 'outputs' referenced before assignment")>
Traceback (most recent call last):
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 376, in amodel_call
async with session.post(
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 1488, in __aenter__
self._resp: _RetType = await self._coro
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 770, in _request
resp = await handler(req)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 748, in _connect_and_send_request
await resp.start(conn)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 532, in start
message, payload = await protocol.read()  # type: ignore[union-attr]
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/streams.py", line 672, in read
await self._waiter
aiohttp.client_exceptions.ServerDisconnectedError: Server disconnected

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tqdm/asyncio.py", line 76, in wrap_awaitable
return i, await f
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
return await copy(fn, *args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
do = await self.iter(retry_state=retry_state)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
result = await action(retry_state)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/_utils.py", line 99, in inner
return call(*args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/__init__.py", line 420, in exc_check
raise retry_exc.reraise()
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/__init__.py", line 187, in reraise
raise self.last_attempt.result()
File "/home/ubuntu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/concurrent/futures/_base.py", line 451, in result
return self.__get_result()
File "/home/ubuntu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
raise self._exception
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
result = await fn(*args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 407, in amodel_call
eval_logger.error(f"Exception:{repr(e)}, {outputs}, retrying.")
UnboundLocalError: local variable 'outputs' referenced before assignment
2025-09-11:03:23:35,411 ERROR    [base_events.py:1758] Task exception was never retrieved
future: <Task finished name='Task-1685' coro=<tqdm_asyncio.gather.<locals>.wrap_awaitable() done, defined at /opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tqdm/asyncio.py:75> exception=UnboundLocalError("local variable 'outputs' referenced before assignment")>
Traceback (most recent call last):
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 376, in amodel_call
async with session.post(
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 1488, in __aenter__
self._resp: _RetType = await self._coro
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 770, in _request
resp = await handler(req)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 748, in _connect_and_send_request
await resp.start(conn)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 532, in start
message, payload = await protocol.read()  # type: ignore[union-attr]
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/streams.py", line 672, in read
await self._waiter
aiohttp.client_exceptions.ServerDisconnectedError: Server disconnected

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tqdm/asyncio.py", line 76, in wrap_awaitable
return i, await f
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
return await copy(fn, *args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
do = await self.iter(retry_state=retry_state)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
result = await action(retry_state)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/_utils.py", line 99, in inner
return call(*args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/__init__.py", line 420, in exc_check
raise retry_exc.reraise()
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/__init__.py", line 187, in reraise
raise self.last_attempt.result()
File "/home/ubuntu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/concurrent/futures/_base.py", line 451, in result
return self.__get_result()
File "/home/ubuntu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
raise self._exception
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
result = await fn(*args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 407, in amodel_call
eval_logger.error(f"Exception:{repr(e)}, {outputs}, retrying.")
UnboundLocalError: local variable 'outputs' referenced before assignment
2025-09-11:03:23:35,411 ERROR    [base_events.py:1758] Task exception was never retrieved
future: <Task finished name='Task-1369' coro=<tqdm_asyncio.gather.<locals>.wrap_awaitable() done, defined at /opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tqdm/asyncio.py:75> exception=UnboundLocalError("local variable 'outputs' referenced before assignment")>
Traceback (most recent call last):
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 376, in amodel_call
async with session.post(
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 1488, in __aenter__
self._resp: _RetType = await self._coro
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 770, in _request
resp = await handler(req)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client.py", line 748, in _connect_and_send_request
await resp.start(conn)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 532, in start
message, payload = await protocol.read()  # type: ignore[union-attr]
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/aiohttp/streams.py", line 672, in read
await self._waiter
aiohttp.client_exceptions.ServerDisconnectedError: Server disconnected

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tqdm/asyncio.py", line 76, in wrap_awaitable
return i, await f
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
return await copy(fn, *args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
do = await self.iter(retry_state=retry_state)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
result = await action(retry_state)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/_utils.py", line 99, in inner
return call(*args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/__init__.py", line 420, in exc_check
raise retry_exc.reraise()
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/__init__.py", line 187, in reraise
raise self.last_attempt.result()
File "/home/ubuntu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/concurrent/futures/_base.py", line 451, in result
return self.__get_result()
File "/home/ubuntu/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
raise self._exception
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
result = await fn(*args, **kwargs)
File "/opt/runner/_work/tt-shield/tt-shield/tt-inference-server/.workflow_venvs/.venv_evals/lib/python3.10/site-packages/lm_eval/models/api_models.py", line 407, in amodel_call
eval_logger.error(f"Exception:{repr(e)}, {outputs}, retrying.")
UnboundLocalError: local variable 'outputs' referenced before assignment
2025-09-11 03:23:37,452 - run_evals.py:301 - ERROR: ⛔ evals failed with return codes: [1, 1]. See logs above for details.
2025-09-11 03:23:38,461 - run_workflows.py:149 - ERROR: ⛔ workflow: evals, failed with return code: 1
```

### Fix 
* Fixed the UnboundLocalError in `/lm-evaluation-harness/lm_eval/models/api_models.py`
* Line 407: `outputs` → `outputs_str = locals().get('outputs', 'undefined')`
* Prevents crashes during retry attempts
