### PR TITLE
Add RULER Long Context Eval with 128K Support

### DIFF
--- a/lm_eval/tasks/ruler_long/README.md
+++ b/lm_eval/tasks/ruler_long/README.md
@@ -1,0 +1,71 @@
+# Task-name
+
+### Paper
+
+Title: `RULER: What’s the Real Context Size of Your Long-Context Language Models?`
+
+Abstract: `https://arxiv.org/abs/2404.06654`
+
+`RULER expands upon the vanilla NIAH test to encompass variations with diverse types and quantities of needles. Moreover, RULER introduces new task categories multi-hop tracing and aggregation to test behaviors beyond searching from context. We evaluate 17 long-context LMs with 13 representative tasks in RULER.`
+
+Homepage: `https://github.com/NVIDIA/RULER`
+
+> [!NOTE]
+> When using Ruler tasks, please note:
+> 1. A tokenizer is required for data processing. The system will use the `tokenizer` from model_args, or fall back to the tokenizer associated with the `pretrained` model name.
+> 2. The default maximum sequence length is 4096. For calculating metrics of different max seq lengths, specify additional lengths using the metadata parameter:
+>   `--metadata='{"max_seq_lengths":[4096,8192,16384,32768,65536,131072]}'`. The metadata parameter can also be passed to the TaskManager (metadata: dict).
+> 3. To prevent truncation of longer sequences, we recommend setting the max_length parameter in model_args:
+>   `--model_args=pretrained=...,max_length=32768`
+
+### Citation
+
+```
+@article{hsieh2024ruler,
+  title={RULER: What's the Real Context Size of Your Long-Context Language Models?},
+  author={Cheng-Ping Hsieh and Simeng Sun and Samuel Kriman and Shantanu Acharya and Dima Rekesh and Fei Jia and Yang Zhang and Boris Ginsburg},
+  year={2024},
+  journal={arXiv preprint arXiv:2404.06654},
+}
+```
+
+### Groups, Tags, and Tasks
+
+#### Groups
+
+* `ruler`: `All 13 tasks in the RULER benchmark`
+
+#### Tags
+
+`longcxt`: `Long-context tasks`
+
+#### Tasks
+
+* `niah_single_1`: `NIAH single needle; key=word,value=number,haystack=repeat ∼passkey retrieval`
+* `niah_single_2`: `NIAH single needle; key=word,value=number,haystack=essay ∼vanilla NIAH`
+* `niah_single_3`: `NIAH single needle; key=word,value=uuid,haystack=essay`
+* `niah_multikey_1`: `NIAH multi-key, ∼line retrieval`
+* `niah_multikey_2`: `NIAH multi-key, ∼KV retrieval`
+* `niah_multikey_3`: `NIAH multi-key, `
+* `niah_multiquery`: `NIA multi-query`
+* `niah_multivalue`: `NIAH multi-value`
+* `ruler_vt`: `Variation tracing`
+* `ruler_cwe`: `Common word extraction`
+* `ruler_fwe`: `Frequent word extraction`
+* `ruler_qa_hotpot`: `QA Hotpot`
+* `ruler_qa_squad`: `QA SQuADv2`
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [x] Is the "Main" variant of this task clearly denoted?
+* [x] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [x] Have you noted which, if any, published evaluation setups are matched by this variant?
+
+### Changelog

--- a/lm_eval/tasks/ruler_long/README.md
+++ b/lm_eval/tasks/ruler_long/README.md
@@ -1,8 +1,8 @@
-# Task-name
+# Task-name: RULER Long (128K)
 
 ### Paper
 
-Title: `RULER: What’s the Real Context Size of Your Long-Context Language Models?`
+Title: `RULER: What's the Real Context Size of Your Long-Context Language Models?`
 
 Abstract: `https://arxiv.org/abs/2404.06654`
 
@@ -11,12 +11,21 @@ Abstract: `https://arxiv.org/abs/2404.06654`
 Homepage: `https://github.com/NVIDIA/RULER`
 
 > [!NOTE]
+> This is the `ruler_long` variant with **7 core subtasks** testing up to **128K context**. Optimized for T3K hardware.
+> For comprehensive testing with all 13 subtasks (up to 65K), use the standard `ruler` task (N300-compatible).
+
+**Key Differences from `ruler`:**
+- Tests up to 128K context (vs 65K)
+- Streamlined to 7 subtasks (vs 13) to fit within CI time constraints
+- Requires T3K or larger hardware due to memory requirements
+
+> [!NOTE]
 > When using Ruler tasks, please note:
 > 1. A tokenizer is required for data processing. The system will use the `tokenizer` from model_args, or fall back to the tokenizer associated with the `pretrained` model name.
 > 2. The default maximum sequence length is 4096. For calculating metrics of different max seq lengths, specify additional lengths using the metadata parameter:
 >   `--metadata='{"max_seq_lengths":[4096,8192,16384,32768,65536,131072]}'`. The metadata parameter can also be passed to the TaskManager (metadata: dict).
 > 3. To prevent truncation of longer sequences, we recommend setting the max_length parameter in model_args:
->   `--model_args=pretrained=...,max_length=32768`
+>   `--model_args=pretrained=...,max_length=131072`
 
 ### Citation
 
@@ -33,26 +42,24 @@ Homepage: `https://github.com/NVIDIA/RULER`
 
 #### Groups
 
-* `ruler`: `All 13 tasks in the RULER benchmark`
+* `ruler_long`: `RULER benchmark with 128K context support (streamlined to 7 core subtasks)`
 
 #### Tags
 
 `longcxt`: `Long-context tasks`
 
-#### Tasks
+#### Tasks (7 Core Subtasks)
 
 * `niah_single_1`: `NIAH single needle; key=word,value=number,haystack=repeat ∼passkey retrieval`
-* `niah_single_2`: `NIAH single needle; key=word,value=number,haystack=essay ∼vanilla NIAH`
-* `niah_single_3`: `NIAH single needle; key=word,value=uuid,haystack=essay`
+<!-- * `niah_single_2`: `NIAH single needle; key=word,value=number,haystack=essay ∼vanilla NIAH`
+* `niah_single_3`: `NIAH single needle; key=word,value=uuid,haystack=essay` -->
 * `niah_multikey_1`: `NIAH multi-key, ∼line retrieval`
-* `niah_multikey_2`: `NIAH multi-key, ∼KV retrieval`
-* `niah_multikey_3`: `NIAH multi-key, `
 * `niah_multiquery`: `NIA multi-query`
-* `niah_multivalue`: `NIAH multi-value`
+<!-- * `niah_multivalue`: `NIAH multi-value` -->
 * `ruler_vt`: `Variation tracing`
 * `ruler_cwe`: `Common word extraction`
 * `ruler_fwe`: `Frequent word extraction`
-* `ruler_qa_hotpot`: `QA Hotpot`
+<!-- * `ruler_qa_hotpot`: `QA Hotpot` -->
 * `ruler_qa_squad`: `QA SQuADv2`
 
 ### Checklist

--- a/lm_eval/tasks/ruler_long/common_utils.py
+++ b/lm_eval/tasks/ruler_long/common_utils.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 eval_logger = logging.getLogger(__name__)
 
 DEFAULT_SEQ_LENGTHS = [
-    4096, 8192, 16384, 32768, 65536,
+    4096, 8192, 16384, 32768, 65536, 131072,
 ]
 
 

--- a/lm_eval/tasks/ruler_long/common_utils.py
+++ b/lm_eval/tasks/ruler_long/common_utils.py
@@ -1,0 +1,106 @@
+import logging
+import re
+from functools import cache
+from typing import TYPE_CHECKING, Union
+
+from transformers import AutoTokenizer
+
+
+if TYPE_CHECKING:
+    import transformers
+
+
+eval_logger = logging.getLogger(__name__)
+
+DEFAULT_SEQ_LENGTHS = [
+    4096, 8192, 16384, 32768, 65536,
+]
+
+
+@cache
+def get_tokenizer(
+    tokenizer=None, pretrained=None, **kwargs
+) -> Union["transformers.PreTrainedTokenizer", "transformers.PreTrainedTokenizerFast"]:
+    pretrained = tokenizer or pretrained
+    assert pretrained, "No tokenizer or pretrained provided."
+    eval_logger.info(f"Using tokenizer {pretrained} for synthetic tasks.")
+    return AutoTokenizer.from_pretrained(pretrained, trust_remote_code=True)
+
+# ------------------------------------------------------------------
+# Limiting utilities
+# ------------------------------------------------------------------
+
+
+def get_limit_factor(kwargs: dict) -> float:
+    """Return per-length limiting factor from kwargs metadata.
+    
+    Args:
+        kwargs: Task kwargs containing metadata with limit_factor
+    
+    Returns:
+        float: Limiting factor (1.0 = no limiting, 0.1 = 10% of samples, etc.)
+    """
+    return float(kwargs.pop("limit_factor", 1.0))
+
+
+def postprocess_pred(prediction: list[str]) -> list[str]:
+    res = []
+    for predict_str in prediction:
+        predict_str = predict_str.strip()
+
+        # Remove all non-printable characters
+        np_pattern = re.compile(r"[\x00-\x1f]")
+        predict_str = np_pattern.sub("\n", predict_str).strip()
+        res.append(predict_str)
+
+    return res
+
+
+def string_match_all(preds: list[str], refs: list[list[str]]) -> float:
+    score = sum(
+        [
+            sum([1.0 if r.lower() in pred.lower() else 0.0 for r in ref]) / len(ref)
+            for pred, ref in zip(preds, refs)
+        ]
+    ) / len(preds)
+    return score
+
+
+def string_match_part(preds: list[str], refs: list[list[str]]) -> float:
+    score = max(
+        [
+            sum([1.0 if r.lower() in pred.lower() else 0.0 for r in ref]) / len(ref)
+            for pred, ref in zip(preds, refs)
+        ]
+    ) / len(preds)
+    return score
+
+
+def process_results(doc: dict, results: list[str]) -> dict[str, float]:
+    # Use max_seq_lengths from metadata if available, fallback to DEFAULT_SEQ_LENGTHS
+    seq_lengths = doc.get("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    metrics = {str(length): -1.0 for length in seq_lengths}
+    input_len = doc["max_length"]
+    pred = postprocess_pred(results)
+    score = string_match_all(pred, [doc["outputs"]])
+    metrics[str(input_len)] = score
+    return metrics
+
+
+def process_results_part(doc: dict, results: list[str]) -> dict[str, float]:
+    # Use max_seq_lengths from metadata if available, fallback to DEFAULT_SEQ_LENGTHS
+    seq_lengths = doc.get("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    metrics = {str(length): -1.0 for length in seq_lengths}
+    input_len = doc["max_length"]
+    pred = postprocess_pred(results)
+    score = string_match_part(pred, [doc["outputs"]])
+    metrics[str(input_len)] = score
+    return metrics
+
+
+def aggregate_metrics(metrics: list[float]) -> float:
+    res = [x for x in metrics if x != -1]
+    if not res:
+        # we don't have any samples with this length
+        return -1
+    return sum(res) / len(res)

--- a/lm_eval/tasks/ruler_long/cwe.yaml
+++ b/lm_eval/tasks/ruler_long/cwe.yaml
@@ -1,0 +1,9 @@
+include: niah_single_1.yaml
+task: ruler_cwe
+custom_dataset: !function cwe_utils.get_cw_dataset
+target_delimiter: "\n\n"
+generation_kwargs:
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 120
+  until: []

--- a/lm_eval/tasks/ruler_long/cwe_utils.py
+++ b/lm_eval/tasks/ruler_long/cwe_utils.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+import itertools
+import random
+
+import datasets
+import wonderwords
+from tqdm import tqdm
+
+from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
+
+
+CONFIG = {
+    "tokens_to_generate": 120,
+    "template": """Below is a numbered list of words. In these words, some appear more often than others. Memorize the ones that appear most often.\n{context}\nQuestion: What are the 10 most common words in the above list?""",
+    "answer_prefix": """ Answer: The top 10 words that appear most often in the list are:""",
+}
+
+RNG = random.Random(42)
+TEMPLATE = CONFIG["template"] + CONFIG["answer_prefix"]
+
+
+r = wonderwords.RandomWord()
+WORDS = sorted(
+    list(
+        set([item for x in ["noun", "adjective", "verb"] for item in r._categories[x]])
+    )
+)
+RNG.shuffle(WORDS)
+
+
+def get_example(num_words, common_repeats=30, uncommon_repeats=3, common_nums=10):
+    word_list_full = random.sample(WORDS, num_words)
+    common, uncommon = word_list_full[:common_nums], word_list_full[common_nums:]
+    word_list = common * int(common_repeats) + uncommon * int(uncommon_repeats)
+    RNG.shuffle(word_list)
+
+    # Formatting the word list as "1. word1 2. word2 3. word3 ..."
+    context = " ".join([f"{i + 1}. {word}" for i, word in enumerate(word_list)])
+
+    return context, common
+
+
+def generate_input_output(
+    num_words: int,
+    max_seq_length: int,
+    freq_cw: int = 30,
+    freq_ucw: int = 3,
+    num_cw: int = 10,
+):
+    if max_seq_length < 4096:
+        context_example, answer_example = get_example(20, 3, 1, num_cw)
+        context, answer = get_example(num_words, 6, 1, num_cw)
+    else:
+        context_example, answer_example = get_example(40, 10, 3, num_cw)
+        context, answer = get_example(num_words, freq_cw, freq_ucw, num_cw)
+
+    template = TEMPLATE
+
+    input_example = template.format(
+        context=context_example,
+        query="",
+    ) + " ".join([f"{i + 1}. {word}" for i, word in enumerate(answer_example)])
+
+    input_text = template.format(
+        context=context,
+        query="",
+    )
+
+    return input_example, input_text, answer
+
+
+def sys_word_pair_random(
+    num_samples: int,
+    max_seq_length: int,
+    tokenizer=None,
+    incremental: int = 10,
+    remove_newline_tab=False,
+    tokens_to_generate=120,
+):
+    assert tokenizer is not None, "Tokenizer is not provided."
+    write_jsons = []
+    tokens_to_generate = tokens_to_generate
+
+    # Find the perfect num_words
+    num_words = incremental
+
+    total_tokens = 0
+    while total_tokens + tokens_to_generate < max_seq_length:
+        input_example, input_text, answer = generate_input_output(
+            num_words, max_seq_length
+        )
+        # Calculate the number of tokens in the example
+        total_tokens = len(
+            tokenizer(
+                input_example
+                + "\n"
+                + input_text
+                + " "
+                + " ".join([f"{i + 1}. {word}" for i, word in enumerate(answer)])
+            ).input_ids
+        )
+        # print(
+        #     f"Max length {max_seq_length} | Current length {total_tokens + tokens_to_generate} | Words: {num_words}"
+        # )
+        if total_tokens + tokens_to_generate > max_seq_length:
+            num_words -= incremental
+            break
+
+        num_words += incremental
+        if num_words > len(WORDS):
+            num_words = len(WORDS)
+            break
+
+    # print("num_words:", num_words)
+
+    # Generate samples
+    for index in tqdm(
+        range(num_samples), desc=f"Generating CWE Samples | {max_seq_length}"
+    ):
+        used_words = num_words
+        while True:
+            try:
+                input_example, input_text, answer = generate_input_output(
+                    used_words, max_seq_length
+                )
+                length = len(tokenizer(input_text).input_ids) + tokens_to_generate
+                assert length <= max_seq_length, f"{length} exceeds max_seq_length."
+                break
+            except:  # noqa: E722
+                if used_words > incremental:
+                    used_words -= incremental
+
+        if remove_newline_tab:
+            input_text = " ".join(
+                input_text.replace("\n", " ").replace("\t", " ").strip().split()
+            )
+            input_example = " ".join(
+                input_example.replace("\n", " ").replace("\t", " ").strip().split()
+            )
+
+        gen_prefix_index = input_text.rfind(CONFIG["answer_prefix"])
+        input_text = input_text[:gen_prefix_index]
+        formatted_output = {
+            "index": index,
+            "input": input_text.strip(),
+            "input_example": input_example,
+            "outputs": answer,
+            "length": length,
+            "max_length": max_seq_length,
+            "gen_prefix": CONFIG["answer_prefix"].strip(),
+        }
+        write_jsons.append(formatted_output)
+
+    return write_jsons
+
+
+def get_dataset(pretrained, seq=None, num_samples=500, **kwargs):
+    tokenizer = get_tokenizer(pretrained)
+    write_jsons = sys_word_pair_random(
+        num_samples=num_samples, max_seq_length=seq, tokenizer=tokenizer
+    )
+    return write_jsons
+
+
+def get_cw_dataset(**kwargs):
+    pretrained = kwargs.get("tokenizer", kwargs.get("pretrained", {}))
+    base_samples = kwargs.pop("num_samples_per_length", 500)  # Base sample count
+    limit_factor = get_limit_factor(kwargs)
+    num_samples  = int(base_samples * limit_factor)
+    df = (
+        get_dataset(pretrained, seq=seq, num_samples=num_samples)
+        for seq in kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    )
+
+    return {
+        "test": datasets.Dataset.from_list(
+            list(itertools.chain.from_iterable(df)), split=datasets.Split.TEST
+        )
+    }

--- a/lm_eval/tasks/ruler_long/cwe_utils.py
+++ b/lm_eval/tasks/ruler_long/cwe_utils.py
@@ -18,7 +18,7 @@ import datasets
 import wonderwords
 from tqdm import tqdm
 
-from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
+from lm_eval.tasks.ruler_long.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
 
 
 CONFIG = {

--- a/lm_eval/tasks/ruler_long/essays.py
+++ b/lm_eval/tasks/ruler_long/essays.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+import asyncio
+import glob
+import os
+from functools import cache
+from typing import Dict
+
+import html2text
+import httpx
+from bs4 import BeautifulSoup
+from tqdm.asyncio import tqdm as async_tqdm
+
+
+@cache
+async def fetch_url(client: httpx.AsyncClient, url: str) -> str:
+    response = await client.get(url)
+    response.raise_for_status()
+    return response.text
+
+
+@cache
+async def process_html_essay(
+    client: httpx.AsyncClient, url: str, h: html2text.HTML2Text, temp_folder: str
+) -> None:
+    filename = url.split("/")[-1].replace(".html", ".txt")
+    if os.path.exists(os.path.join(temp_folder, filename)):
+        return None
+    try:
+        content = await fetch_url(client, url)
+        soup = BeautifulSoup(content, "html.parser")
+        specific_tag = soup.find("font")
+        if specific_tag:
+            parsed = h.handle(str(specific_tag))
+
+            with open(
+                os.path.join(temp_folder, filename), "w", encoding="utf-8"
+            ) as file:
+                file.write(parsed)
+    except Exception as e:
+        print(f"Failed to download {filename}: {str(e)}")
+
+
+@cache
+async def process_text_essay(
+    client: httpx.AsyncClient, url: str, temp_folder: str
+) -> None:
+    filename = url.split("/")[-1]
+    if os.path.exists(os.path.join(temp_folder, filename)):
+        return None
+    try:
+        content = await fetch_url(client, url)
+        with open(os.path.join(temp_folder, filename), "w", encoding="utf-8") as file:
+            file.write(content)
+    except Exception as e:
+        print(f"Failed to download {filename}: {str(e)}")
+
+
+@cache
+async def get_essays() -> Dict[str, str]:
+    """
+    Get Paul Graham essays with fallback for CI environments.
+    
+    First attempts to download from original GitHub URLs. If that fails (e.g., due to
+    network restrictions in CI), falls back to HuggingFace datasets or synthetic content.
+    """
+    try:
+        # Try original download method first
+        temp_folder_repo = "essay_repo"
+        temp_folder_html = "essay_html"
+        os.makedirs(temp_folder_repo, exist_ok=True)
+        os.makedirs(temp_folder_html, exist_ok=True)
+
+        h = html2text.HTML2Text()
+        h.ignore_images = True
+        h.ignore_tables = True
+        h.escape_all = True
+        h.reference_links = False
+        h.mark_code = False
+
+        url_list = "https://raw.githubusercontent.com/NVIDIA/RULER/main/scripts/data/synthetic/json/PaulGrahamEssays_URLs.txt"
+
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            # Fetch URL list
+            content = await fetch_url(client, url_list)
+            urls = content.splitlines()
+
+            # Separate HTML and text URLs
+            html_urls = [url for url in urls if ".html" in url]
+            text_urls = [url for url in urls if ".html" not in url]
+
+            # Process HTML essays
+            html_tasks = [
+                process_html_essay(client, url, h, temp_folder_html) for url in html_urls
+            ]
+            await async_tqdm.gather(*html_tasks, desc="Downloading HTML essays")
+
+            # Process text essays
+            text_tasks = [
+                process_text_essay(client, url, temp_folder_repo) for url in text_urls
+            ]
+            await async_tqdm.gather(*text_tasks, desc="Downloading text essays")
+
+        # Collect results
+        files_repo = sorted(glob.glob(os.path.join(temp_folder_repo, "*.txt")))
+        files_html = sorted(glob.glob(os.path.join(temp_folder_html, "*.txt")))
+
+        # Combine all texts
+        text = ""
+        for file in files_repo + files_html:
+            with open(file, "r", encoding="utf-8") as f:
+                text += f.read()
+
+        print("Successfully downloaded Paul Graham essays from original URLs")
+        return {"text": text}
+        
+    except Exception as e:
+        print(f"Failed to download essays from original URLs ({e}), falling back to alternative content")
+        
+        try:
+            # Try HuggingFace datasets fallback
+            import datasets
+            
+            # Try to find a suitable text dataset for long-form content
+            # Using a well-known dataset that should work in CI environments
+            dataset = datasets.load_dataset("wikitext", "wikitext-103-v1", split="train")
+            
+            # Take a reasonable subset and combine into essay-like format
+            texts = []
+            char_count = 0
+            target_chars = 100000  # Target around 100k characters
+            
+            for item in dataset:
+                if char_count >= target_chars:
+                    break
+                text_content = item["text"].strip()
+                if len(text_content) > 100:  # Skip very short entries
+                    texts.append(text_content)
+                    char_count += len(text_content)
+            
+            combined_text = "\n\n".join(texts)
+            print(f"Successfully loaded {len(texts)} text samples from HuggingFace (WikiText), {len(combined_text)} characters total")
+            
+            return {"text": combined_text}
+            
+        except Exception as hf_error:
+            print(f"HuggingFace fallback also failed ({hf_error}), using synthetic essay content")
+            
+            # Ultimate fallback: Generate synthetic essay-like content
+            synthetic_essays = [
+                "The Nature of Startups\n\nStartups are fundamentally different from big companies. They are designed to grow fast, and this changes everything about how they operate. In a startup, you're not just building a product; you're searching for a repeatable business model.\n\nThe key insight is that startups are temporary organizations designed to search for a repeatable and scalable business model. This means that most of what you do in a startup is experimentation.",
+                
+                "On Writing and Thinking\n\nWriting is thinking. When you sit down to write, you discover what you actually think about a subject. The process of writing forces you to organize your thoughts, to find the connections between ideas, and to express them clearly.\n\nMany people think they know what they want to say, but it's only when they start writing that they realize their ideas are fuzzy or incomplete. Writing is a tool for thinking, not just for communication.",
+                
+                "The Value of Being Wrong\n\nBeing wrong is undervalued. In school, being wrong is penalized. In startups and research, being wrong is valuable information. It tells you what doesn't work, which narrows down what might work.\n\nThe key is to be wrong quickly and cheaply. Run small experiments, get feedback fast, and iterate. The goal is not to avoid being wrong, but to be wrong efficiently.",
+                
+                "Technology and Progress\n\nTechnology doesn't just change what we can do; it changes what we want to do. When new technologies emerge, they don't just make old things easier—they make entirely new things possible.\n\nThe most interesting technologies are those that create new desires, not just fulfill existing ones. The internet didn't just make mail faster; it created entirely new forms of communication and collaboration.",
+                
+                "The Importance of Focus\n\nFocus is about saying no. It's easy to say yes to everything, but that leads to mediocrity. The hardest part of focus is not deciding what to do, but deciding what not to do.\n\nIn startups, focus is even more critical. With limited resources and time, every decision matters. You have to pick the few things that will have the biggest impact and ignore everything else."
+            ]
+            
+            combined_synthetic = "\n\n" + "="*50 + "\n\n".join(synthetic_essays)
+            print(f"Using synthetic essay content ({len(combined_synthetic)} characters)")
+            
+            return {"text": combined_synthetic}
+
+
+@cache
+def get_all_essays() -> Dict[str, str]:
+    """Synchronous wrapper for get_essays()"""
+    return asyncio.run(get_essays())

--- a/lm_eval/tasks/ruler_long/fwe.yaml
+++ b/lm_eval/tasks/ruler_long/fwe.yaml
@@ -1,0 +1,8 @@
+include: niah_single_1.yaml
+task: ruler_fwe
+custom_dataset: !function fwe_utils.fwe_download
+generation_kwargs:
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 50
+  until: []

--- a/lm_eval/tasks/ruler_long/fwe_utils.py
+++ b/lm_eval/tasks/ruler_long/fwe_utils.py
@@ -21,7 +21,7 @@ import transformers
 from scipy.special import zeta
 from tqdm import tqdm
 
-from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
+from lm_eval.tasks.ruler_long.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
 
 
 CONFIG = {

--- a/lm_eval/tasks/ruler_long/fwe_utils.py
+++ b/lm_eval/tasks/ruler_long/fwe_utils.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+import itertools
+import random
+import string
+
+import datasets
+import numpy as np
+import transformers
+from scipy.special import zeta
+from tqdm import tqdm
+
+from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
+
+
+CONFIG = {
+    "tokens_to_generate": 50,
+    "template": """Read the following coded text and track the frequency of each coded word. Find the three most frequently appeared coded words. {context}\nQuestion: Do not provide any explanation. Please ignore the dots '....'. What are the three most frequently appeared words in the above coded text?""",
+    "answer_prefix": """ Answer: According to the coded text above, the three most frequently appeared words are:""",
+}
+
+
+SEED = 42
+TEMPLATE = CONFIG["template"] + CONFIG["answer_prefix"]
+
+
+def generate_input_output(
+    max_len: int,
+    tokenizer: "transformers.PreTrainedTokenizerFast",
+    num_words=-1,
+    coded_wordlen=6,
+    vocab_size=2000,
+    incremental=10,
+    alpha=2.0,
+) -> tuple[str, list[str], int]:
+    # generate vocab
+    vocab = [
+        "".join(random.choices(string.ascii_lowercase, k=coded_wordlen))
+        for _ in range(vocab_size)
+    ]
+    while len(set(vocab)) < vocab_size:
+        vocab.append("".join(random.choices(string.ascii_lowercase, k=coded_wordlen)))
+    vocab = sorted(list(set(vocab)))
+    random.Random(SEED).shuffle(vocab)
+    vocab[0] = "..."  # treat the top ranked as noise
+
+    # sample words
+    template = TEMPLATE
+
+    def gen_text(num_words):
+        k = np.arange(1, len(vocab) + 1)
+        sampled_cnt = num_words * (k**-alpha) / zeta(alpha)
+        sampled_words = [[w] * zi for w, zi in zip(vocab, sampled_cnt.astype(int))]
+        sampled_words = [x for wlst in sampled_words for x in wlst]
+        random.Random(SEED).shuffle(sampled_words)
+        return template.format(context=" ".join(sampled_words), query=""), vocab[1:4]
+
+    if num_words > 0:
+        num_words = num_words
+        text, answer = gen_text(num_words)
+        while len(tokenizer(text).input_ids) > max_len:
+            num_words -= incremental
+            text, answer = gen_text(num_words)
+    else:
+        num_words = max_len // coded_wordlen  # init
+        text, answer = gen_text(num_words)
+        while len(tokenizer(text).input_ids) < max_len:
+            num_words += incremental
+            text, answer = gen_text(num_words)
+        num_words -= incremental
+    text, answer = gen_text(num_words)
+    return text, answer, num_words
+
+
+def sys_kwext(
+    tokenizer: "transformers.PreTrainedTokenizerFast",
+    max_seq_length: int,
+    num_samples: int = 500,
+    vocab_size: int = -1,
+    coded_wordlen: int = 6,
+    alpha: float = 2.0,
+    tokens_to_generate: int = 50,
+    remove_newline_tab: bool = False,
+) -> list[dict]:
+    write_jsons = []
+    tokens_to_generate = tokens_to_generate
+
+    vocab_size = max_seq_length // 50 if vocab_size == -1 else vocab_size
+
+    # get number of words
+    input_max_len = max_seq_length
+    _, _, num_example_words = generate_input_output(
+        input_max_len,
+        tokenizer,
+        coded_wordlen=coded_wordlen,
+        vocab_size=vocab_size,
+        incremental=input_max_len // 32,
+        alpha=alpha,
+    )
+    # Generate samples
+    for index in tqdm(
+        range(num_samples), desc=f"Generating FWE Samples | {max_seq_length}"
+    ):
+        # construct input
+        input_max_len = max_seq_length
+        input_text, answer, _ = generate_input_output(
+            input_max_len,
+            tokenizer,
+            num_words=num_example_words,
+            coded_wordlen=coded_wordlen,
+            vocab_size=vocab_size,
+            incremental=input_max_len // 32,
+            alpha=alpha,
+        )
+
+        length = len(tokenizer(input_text).input_ids) + tokens_to_generate
+
+        if remove_newline_tab:
+            input_text = " ".join(
+                input_text.replace("\n", " ").replace("\t", " ").strip().split()
+            )
+
+        formatted_output = {
+            "index": index,
+            "input": input_text[: input_text.rfind(CONFIG["answer_prefix"])].strip(),
+            "outputs": answer,
+            "length": length,
+            "max_length": max_seq_length,
+            "gen_prefix": CONFIG["answer_prefix"].strip(),
+        }
+        write_jsons.append(formatted_output)
+
+    return write_jsons
+
+
+def get_dataset(pretrained, max_seq_length=None, num_samples=500, **kwargs):
+    tokenizer = get_tokenizer(pretrained)
+    write_jsons = sys_kwext(
+        tokenizer=tokenizer,
+        max_seq_length=max_seq_length,
+        num_samples=num_samples,
+    )
+    return write_jsons
+
+
+def fwe_download(**kwargs):
+    pretrained = kwargs.get("tokenizer", kwargs.get("pretrained", {}))
+    base_samples = kwargs.pop("num_samples_per_length", 500)  # Base sample count
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)  # Apply limit per sequence length
+    df = (
+        get_dataset(pretrained, max_seq_length=seq, num_samples=num_samples)
+        for seq in kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    )
+
+    return {
+        "test": datasets.Dataset.from_list(
+            list(itertools.chain.from_iterable(df)), split=datasets.Split.TEST
+        )
+    }

--- a/lm_eval/tasks/ruler_long/niah_multikey_1.yaml
+++ b/lm_eval/tasks/ruler_long/niah_multikey_1.yaml
@@ -1,0 +1,3 @@
+task: niah_multikey_1
+include: niah_single_1.yaml
+custom_dataset: !function niah_utils.niah_multikey_1

--- a/lm_eval/tasks/ruler_long/niah_multikey_2.yaml
+++ b/lm_eval/tasks/ruler_long/niah_multikey_2.yaml
@@ -1,0 +1,3 @@
+task: niah_multikey_2
+include: niah_single_1.yaml
+custom_dataset: !function niah_utils.niah_multikey_2

--- a/lm_eval/tasks/ruler_long/niah_multikey_3.yaml
+++ b/lm_eval/tasks/ruler_long/niah_multikey_3.yaml
@@ -1,0 +1,3 @@
+task: niah_multikey_3
+include: niah_single_1.yaml
+custom_dataset: !function niah_utils.niah_multikey_3

--- a/lm_eval/tasks/ruler_long/niah_multiquery.yaml
+++ b/lm_eval/tasks/ruler_long/niah_multiquery.yaml
@@ -1,0 +1,3 @@
+task: niah_multiquery
+include: niah_single_1.yaml
+custom_dataset: !function niah_utils.niah_multiquery

--- a/lm_eval/tasks/ruler_long/niah_multivalue.yaml
+++ b/lm_eval/tasks/ruler_long/niah_multivalue.yaml
@@ -1,0 +1,3 @@
+task: niah_multivalue
+include: niah_single_1.yaml
+custom_dataset: !function niah_utils.niah_multivalue

--- a/lm_eval/tasks/ruler_long/niah_single_1.yaml
+++ b/lm_eval/tasks/ruler_long/niah_single_1.yaml
@@ -1,0 +1,40 @@
+tag:
+  - longcxt
+task: niah_single_1
+dataset_path: ""
+dataset_name: ""
+output_type: generate_until
+test_split: test
+custom_dataset: !function niah_utils.niah_single_1
+doc_to_text: "{{input}}"
+doc_to_target: "{{outputs}}"
+gen_prefix: "{{gen_prefix}}"
+target_delimiter: " "
+process_results: !function common_utils.process_results
+metric_list:
+  - metric: "4096"
+    aggregation: !function common_utils.aggregate_metrics
+    higher_is_better: true
+  - metric: "8192"
+    aggregation: !function common_utils.aggregate_metrics
+    higher_is_better: true
+  - metric: "16384"
+    aggregation: !function common_utils.aggregate_metrics
+    higher_is_better: true
+  - metric: "32768"
+    aggregation: !function common_utils.aggregate_metrics
+    higher_is_better: true
+  - metric: "65536"
+    aggregation: !function common_utils.aggregate_metrics
+    higher_is_better: true
+  - metric: "131072"
+    aggregation: !function common_utils.aggregate_metrics
+    higher_is_better: true
+generation_kwargs:
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 128
+  until: []
+repeats: 1
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/ruler_long/niah_single_2.yaml
+++ b/lm_eval/tasks/ruler_long/niah_single_2.yaml
@@ -1,0 +1,3 @@
+task: niah_single_2
+include: niah_single_1.yaml
+custom_dataset: !function niah_utils.niah_single_2

--- a/lm_eval/tasks/ruler_long/niah_single_3.yaml
+++ b/lm_eval/tasks/ruler_long/niah_single_3.yaml
@@ -1,0 +1,3 @@
+task: niah_single_3
+include: niah_single_1.yaml
+custom_dataset: !function niah_utils.niah_single_3

--- a/lm_eval/tasks/ruler_long/niah_utils.py
+++ b/lm_eval/tasks/ruler_long/niah_utils.py
@@ -1,0 +1,183 @@
+import itertools
+import logging
+from typing import Generator
+
+import datasets
+
+from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
+from lm_eval.tasks.ruler.prepare_niah import generate_samples, get_haystack
+
+
+TEMPLATE = """Some special magic {type_needle_v} are hidden within the following text. Make sure to memorize it. I will quiz you about the {type_needle_v} afterwards.\n{context}\nWhat are all the special magic {type_needle_v} for {query} mentioned in the provided text?"""
+eval_logger = logging.getLogger(__name__)
+
+
+def download_dataset(df: Generator) -> dict[str, datasets.Dataset]:
+    return {
+        "test": datasets.Dataset.from_list(
+            list(itertools.chain.from_iterable(df)), split=datasets.Split.TEST
+        )
+    }
+
+
+def niah_single_1(**kwargs):
+    seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    base_samples = kwargs.pop("num_samples_per_length", 500)
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)
+    return download_dataset(
+        generate_samples(
+            get_haystack(type_haystack="repeat"),
+            max_seq_length=seq,
+            template=TEMPLATE,
+            type_haystack="repeat",
+            type_needle_k="words",
+            type_needle_v="numbers",
+            num_samples=num_samples,
+            TOKENIZER=get_tokenizer(**kwargs),
+        )
+        for seq in seq_lengths
+    )
+
+
+def niah_single_2(**kwargs):
+    seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    base_samples = kwargs.pop("num_samples_per_length", 500)
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)
+    return download_dataset(
+        generate_samples(
+            get_haystack(type_haystack="essay"),
+            max_seq_length=seq,
+            template=TEMPLATE,
+            type_haystack="essay",
+            type_needle_k="words",
+            type_needle_v="numbers",
+            num_samples=num_samples,
+            TOKENIZER=get_tokenizer(**kwargs),
+        )
+        for seq in seq_lengths
+    )
+
+
+def niah_single_3(**kwargs):
+    seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    base_samples = kwargs.pop("num_samples_per_length", 500)
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)
+    return download_dataset(
+        generate_samples(
+            get_haystack(type_haystack="essay"),
+            max_seq_length=seq,
+            template=TEMPLATE,
+            type_haystack="essay",
+            type_needle_k="words",
+            type_needle_v="uuids",
+            num_samples=num_samples,
+            TOKENIZER=get_tokenizer(**kwargs),
+        )
+        for seq in seq_lengths
+    )
+
+
+def niah_multikey_1(**kwargs):
+    seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    base_samples = kwargs.pop("num_samples_per_length", 500)
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)
+    return download_dataset(
+        generate_samples(
+            get_haystack(type_haystack="essay"),
+            max_seq_length=seq,
+            template=TEMPLATE,
+            type_haystack="essay",
+            type_needle_k="words",
+            type_needle_v="numbers",
+            num_needle_k=4,
+            num_samples=num_samples,
+            TOKENIZER=get_tokenizer(**kwargs),
+        )
+        for seq in seq_lengths
+    )
+
+
+def niah_multikey_2(**kwargs):
+    seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    base_samples = kwargs.pop("num_samples_per_length", 500)
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)
+    return download_dataset(
+        generate_samples(
+            get_haystack(type_haystack="needle"),
+            max_seq_length=seq,
+            template=TEMPLATE,
+            type_haystack="needle",
+            type_needle_k="words",
+            type_needle_v="numbers",
+            num_samples=num_samples,
+            TOKENIZER=get_tokenizer(**kwargs),
+        )
+        for seq in seq_lengths
+    )
+
+
+def niah_multikey_3(**kwargs):
+    seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    base_samples = kwargs.pop("num_samples_per_length", 500)
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)
+    return download_dataset(
+        generate_samples(
+            get_haystack(type_haystack="needle"),
+            max_seq_length=seq,
+            template=TEMPLATE,
+            type_haystack="needle",
+            type_needle_k="uuids",
+            type_needle_v="uuids",
+            num_samples=num_samples,
+            TOKENIZER=get_tokenizer(**kwargs),
+        )
+        for seq in seq_lengths
+    )
+
+
+def niah_multivalue(**kwargs):
+    seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    base_samples = kwargs.pop("num_samples_per_length", 500)
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)
+    return download_dataset(
+        generate_samples(
+            get_haystack(type_haystack="essay"),
+            max_seq_length=seq,
+            template=TEMPLATE,
+            type_haystack="essay",
+            type_needle_k="words",
+            type_needle_v="numbers",
+            num_needle_v=4,
+            num_samples=num_samples,
+            TOKENIZER=get_tokenizer(**kwargs),
+        )
+        for seq in seq_lengths
+    )
+
+
+def niah_multiquery(**kwargs):
+    seq_lengths = kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    base_samples = kwargs.pop("num_samples_per_length", 500)
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)
+    return download_dataset(
+        generate_samples(
+            get_haystack(type_haystack="essay"),
+            max_seq_length=seq,
+            template=TEMPLATE,
+            type_haystack="essay",
+            type_needle_k="words",
+            type_needle_v="numbers",
+            num_needle_q=4,
+            num_samples=num_samples,
+            TOKENIZER=get_tokenizer(**kwargs),
+        )
+        for seq in seq_lengths
+    )

--- a/lm_eval/tasks/ruler_long/niah_utils.py
+++ b/lm_eval/tasks/ruler_long/niah_utils.py
@@ -4,8 +4,8 @@ from typing import Generator
 
 import datasets
 
-from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
-from lm_eval.tasks.ruler.prepare_niah import generate_samples, get_haystack
+from lm_eval.tasks.ruler_long.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
+from lm_eval.tasks.ruler_long.prepare_niah import generate_samples, get_haystack
 
 
 TEMPLATE = """Some special magic {type_needle_v} are hidden within the following text. Make sure to memorize it. I will quiz you about the {type_needle_v} afterwards.\n{context}\nWhat are all the special magic {type_needle_v} for {query} mentioned in the provided text?"""

--- a/lm_eval/tasks/ruler_long/prepare_niah.py
+++ b/lm_eval/tasks/ruler_long/prepare_niah.py
@@ -1,0 +1,352 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+
+import os
+import random
+import re
+import uuid
+from functools import lru_cache, cache
+from typing import List, Union, Literal
+import datasets
+
+import numpy as np
+from packaging.version import parse as parse_version
+from importlib.metadata import version
+
+from tqdm import tqdm
+
+try:
+    import wonderwords
+    import nltk
+    from nltk import sent_tokenize
+except ImportError:
+    raise ImportError(
+        'Please install the `wonderwords` and `nltk` packages to run this script. You can install them with `pip install lm_eval["ruler"]` or`pip install wonderwords nltk`.'
+    )
+
+
+NUM_SAMPLES = 500
+REMOVE_NEWLINE_TAB = ""
+STOP_WORDS = ""
+RANDOM_SEED = 42
+# Define Needle/Haystack Format
+NEEDLE = "One of the special magic {type_needle_v} for {key} is: {value}."
+
+
+# Words
+r = wonderwords.RandomWord()
+
+nouns = r._categories["nouns"]
+adjs = r._categories["adjectives"]
+verbs = r._categories["verbs"]
+words = [f"{adj}-{noun}" for adj in adjs for noun in nouns]
+WORDS = sorted(list(set(words)))
+
+# Positions
+DEPTHS = list(np.round(np.linspace(0, 100, num=40, endpoint=True)).astype(int))
+
+NLTK_MIN_VERSION = "3.9.1"
+RANK = os.environ.get("LOCAL_RANK", "0")
+
+
+@lru_cache(maxsize=1024)
+def cached_sent_tokenize(text: str) -> List[str]:
+    return sent_tokenize(text)
+
+
+def download_nltk_resources():
+    """
+    Download 'punkt_tab' if not already installed, with fallback for CI environments.
+    """
+    assert (nltk_version := parse_version(version("nltk"))) >= parse_version(
+        NLTK_MIN_VERSION
+    ), (
+        f"`nltk` version {nltk_version} is not >= {NLTK_MIN_VERSION}. Please update `nltk` before proceeding--older versions are vulnerable to a remote code execution vulnerability."
+    )
+
+    try:
+        nltk.data.find("tokenizers/punkt_tab")
+        print("NLTK punkt_tab already available")
+    except LookupError:
+        if RANK == "0":
+            try:
+                nltk.download("punkt_tab")
+                print("Downloaded punkt_tab on rank 0")
+            except Exception as e:
+                print(f"Warning: Failed to download NLTK punkt_tab ({e}). Using fallback sentence tokenization.")
+                # NLTK will fall back to basic tokenization methods if punkt is not available
+                # This usually still works for basic sentence splitting
+
+
+download_nltk_resources()
+
+
+def generate_random_number(num_digits=7) -> str:
+    lower_bound = 10 ** (num_digits - 1)
+    upper_bound = 10**num_digits - 1
+    return str(random.randint(lower_bound, upper_bound))
+
+
+def generate_random_word() -> str:
+    word = random.choice(WORDS)
+    return word
+
+
+def generate_random_uuid() -> str:
+    return str(uuid.UUID(int=random.getrandbits(128), version=4))
+
+
+def generate_random(type_needle: str) -> str:
+    if type_needle == "numbers":
+        return generate_random_number()
+    elif type_needle == "words":
+        return generate_random_word()
+    elif type_needle == "uuids":
+        return generate_random_uuid()
+    else:
+        raise NotImplementedError(f"{type_needle} is not implemented.")
+
+
+def generate_input_output(
+    num_haystack: int,
+    haystack: Union[list[str], str],
+    *,
+    type_haystack: str,
+    num_needle_k: int,
+    type_needle_k: str,
+    num_needle_v: int,
+    type_needle_v: str,
+    template: str,
+    num_needle_q: int = 1,
+    random_seed: int = RANDOM_SEED,
+) -> tuple[str, list[str], str]:
+    NEEDLE = "One of the special magic {type_needle_v} for {key} is: {value}."
+    keys, values, needles = [], [], []
+    for _ in range(num_needle_k):
+        keys.append(generate_random(type_needle_k))
+        value = []
+        for _ in range(num_needle_v):
+            value.append(generate_random(type_needle_v))
+            needles.append(
+                NEEDLE.format(
+                    type_needle_v=type_needle_v,
+                    key=keys[-1],
+                    value=value[-1],
+                )
+            )
+        values.append(value)
+
+    random.Random(random_seed).shuffle(needles)
+
+    # Context
+    if type_haystack == "essay":
+        assert isinstance(haystack, list)
+        text = " ".join(haystack[:num_haystack])
+        document_sents = cached_sent_tokenize(text.strip())
+        insertion_positions = (
+            [0]
+            + sorted(
+                [
+                    int(len(document_sents) * (depth / 100))
+                    for depth in random.sample(DEPTHS, len(needles))
+                ]
+            )
+            + [len(document_sents)]
+        )
+        document_sents_list = []
+        for i in range(1, len(insertion_positions)):
+            last_pos = insertion_positions[i - 1]
+            next_pos = insertion_positions[i]
+            document_sents_list.append(" ".join(document_sents[last_pos:next_pos]))
+            if i - 1 < len(needles):
+                document_sents_list.append(needles[i - 1])
+        context = " ".join(document_sents_list)
+
+    else:
+        if type_haystack == "repeat":
+            sentences = [haystack] * num_haystack
+        elif type_haystack == "needle":
+            sentences = [
+                haystack.format(
+                    type_needle_v=type_needle_v,
+                    key=generate_random(type_needle_k),
+                    value=generate_random(type_needle_v),
+                )
+                for _ in range(num_haystack)
+            ]
+
+        indexes = sorted(random.sample(range(num_haystack), len(needles)), reverse=True)
+        for index, element in zip(indexes, needles):
+            sentences.insert(index, element)
+        context = "\n".join(sentences)
+
+    ## Query and Answer
+    indices = random.sample(range(num_needle_k), num_needle_q)
+    queries = [keys[i] for i in indices]
+    answers = [a for i in indices for a in values[i]]
+    query = (
+        ", ".join(queries[:-1]) + ", and " + queries[-1]
+        if len(queries) > 1
+        else queries[0]
+    )
+
+    template = template
+    type_needle_v = type_needle_v
+    if num_needle_q * num_needle_v == 1:
+        template = template.replace("Some", "A")
+        template = template.replace("are all", "is")
+        template = template.replace("are", "is")
+        template = template.replace("answers", "answer")
+        type_needle_v = type_needle_v[:-1]  # remove "s"
+
+    input_text = template.format(
+        type_needle_v=type_needle_v,
+        context=context,
+        query=query,
+    )
+
+    return input_text, answers, query
+
+
+def generate_samples(
+    haystack,
+    TOKENIZER=None,
+    *,
+    max_seq_length: int,
+    type_haystack: str,
+    type_needle_k: str,
+    type_needle_v: str,
+    template: str,
+    num_samples: int = 500,
+    tokens_to_generate: int = 128,
+    num_needle_v: int = 1,
+    num_needle_k: int = 1,
+    num_needle_q=1,
+    incremental: int = 500,
+    remove_newline_tab: bool = False,
+    random_seed: int = 42,
+) -> list[dict]:
+    assert TOKENIZER is not None, "TOKENIZER is not defined."
+    num_needle_k = max(num_needle_k, num_needle_q)
+    write_jsons = []
+    tokens_to_generate = tokens_to_generate
+
+    if type_haystack == "essay":
+        incremental = 500
+    elif type_haystack == "repeat":
+        incremental = 25
+    elif type_haystack == "needle":
+        incremental = 25
+
+    if type_haystack != "essay" and max_seq_length < 4096:
+        incremental = 5
+
+    num_haystack = incremental
+
+    total_tokens = 0  # Track the total tokens generated for the first example
+    while total_tokens + tokens_to_generate < max_seq_length:
+        input_text, answer, query = generate_input_output(
+            num_haystack,
+            haystack,
+            type_haystack=type_haystack,
+            num_needle_k=num_needle_k,
+            type_needle_k=type_needle_k,
+            num_needle_v=num_needle_v,
+            type_needle_v=type_needle_v,
+            template=template,
+            num_needle_q=num_needle_q,
+            random_seed=random_seed,
+        )
+        # Calculate the number of tokens in the example
+        total_tokens = len(TOKENIZER(input_text + " ".join(answer)).input_ids)
+        if total_tokens + tokens_to_generate > max_seq_length:
+            num_haystack -= incremental
+            break
+
+        if type_haystack == "essay" and num_haystack > len(haystack):
+            num_haystack = len(haystack)
+            break
+
+        num_haystack += incremental
+
+    # print("Num haystack:", num_haystack)
+
+    # Generate samples
+    for index in tqdm(
+        range(num_samples),
+        desc=f"Generating synthetic samples: {type_haystack} | {max_seq_length}",
+    ):
+        used_haystack = num_haystack
+        while True:
+            try:
+                input_text, answer, query = generate_input_output(
+                    used_haystack,
+                    haystack,
+                    type_haystack=type_haystack,
+                    num_needle_k=num_needle_k,
+                    type_needle_k=type_needle_k,
+                    num_needle_v=num_needle_v,
+                    type_needle_v=type_needle_v,
+                    template=template,
+                    num_needle_q=num_needle_q,
+                    random_seed=random_seed,
+                )
+                length = len(TOKENIZER(input_text).input_ids) + tokens_to_generate
+                assert length <= max_seq_length, f"{length} exceeds max_seq_length."
+                break
+                # ruff: noqa
+            except:
+                if used_haystack > incremental:
+                    used_haystack -= incremental
+
+        if remove_newline_tab:
+            input_text = " ".join(
+                input_text.replace("\n", " ").replace("\t", " ").strip().split()
+            )
+
+        formatted_output = {
+            "index": index,
+            "input": input_text,
+            "outputs": answer,
+            "length": length,
+            "max_length": max_seq_length,
+            "gen_prefix": f"The special magic {type_needle_v[:-1]} for {query} mentioned in the provided text is"
+            if num_needle_q * num_needle_v == 1
+            else f"The special magic {type_needle_v} for {query} mentioned in the provided text are",
+        }
+        if formatted_output["outputs"][0] not in formatted_output["input"]:
+            assert False, (
+                f"Needle not in input: {formatted_output}. Something went wrong."
+            )
+        write_jsons.append(formatted_output)
+    return write_jsons
+
+
+@cache
+def get_haystack(
+    type_haystack: Literal["essay", "repeat", "needle"],
+) -> Union[list[str], str]:
+    NEEDLE = "One of the special magic {type_needle_v} for {key} is: {value}."
+    if type_haystack == "essay":
+        essay = datasets.load_dataset("baber/paul_graham_essays", split="train")["text"]
+        essay = " ".join(essay)
+        haystack = re.sub(r"\s+", " ", essay).split(" ")
+    elif type_haystack == "repeat":
+        haystack = "The grass is green. The sky is blue. The sun is yellow. Here we go. There and back again."
+    elif type_haystack == "needle":
+        haystack = NEEDLE
+    else:
+        raise NotImplementedError(f"{type_haystack} is not implemented.")
+    return haystack

--- a/lm_eval/tasks/ruler_long/qa_hotpot.yaml
+++ b/lm_eval/tasks/ruler_long/qa_hotpot.yaml
@@ -1,0 +1,3 @@
+include: qa_squad.yaml
+task: ruler_qa_hotpot
+custom_dataset: !function qa_utils.get_hotpotqa

--- a/lm_eval/tasks/ruler_long/qa_squad.yaml
+++ b/lm_eval/tasks/ruler_long/qa_squad.yaml
@@ -1,0 +1,10 @@
+include: niah_single_1.yaml
+task: ruler_qa_squad
+custom_dataset: !function qa_utils.get_squad
+process_results: !function common_utils.process_results_part
+test_split: test
+generation_kwargs:
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 32
+  until: []

--- a/lm_eval/tasks/ruler_long/qa_utils.py
+++ b/lm_eval/tasks/ruler_long/qa_utils.py
@@ -1,0 +1,337 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+
+import itertools  # noqa: I001
+import random
+from functools import cache
+
+import datasets
+import requests
+from tqdm import tqdm
+
+from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
+
+CONFIG = {
+    "tokens_to_generate": 32,
+    "template": """Answer the question based on the given documents. Only give me the answer and do not output any other words.\n\nThe following are given documents.\n\n{context}\n\nAnswer the question based on the given documents. Only give me the answer and do not output any other words.\n\nQuestion: {query}""",
+    "answer_prefix": """Answer:""",
+}
+SEED = 42
+TEMPLATE = CONFIG["template"]
+DOCUMENT_PROMPT = "Document {i}:\n{document}"
+
+
+@cache
+def download_json(url) -> dict:
+    response = requests.get(url)
+    response.raise_for_status()
+    data = response.json()
+    return data
+
+
+@cache
+def read_squad(
+    url="https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json",
+) -> tuple[list[dict], list[str]]:
+    """
+    Read SQuAD dataset with fallback to HuggingFace datasets for CI environments.
+    
+    First attempts to download from the original SQuAD URL. If that fails (e.g., due to
+    network restrictions in CI), falls back to loading from HuggingFace datasets.
+    """
+    try:
+        # Try original URL first
+        data = download_json(url)
+        print(f"Successfully loaded SQuAD from original URL: {url}")
+    except Exception as e:
+        print(f"Failed to download SQuAD from original URL ({e}), falling back to HuggingFace datasets")
+        
+        try:
+            # Fallback to HuggingFace datasets
+            dataset = datasets.load_dataset("squad_v2", split="validation")
+            
+            # Convert HuggingFace dataset to expected format
+            # HF format: {'context': str, 'answers': {'text': [...], 'answer_start': [...]}}
+            # Original format: nested structure with data.data.paragraphs.qas
+            data = {"data": []}
+            contexts_seen = {}
+            
+            for item in dataset:
+                # Only process items that have answers (not impossible questions)
+                if item["answers"]["text"]:  # Skip impossible questions
+                    context = item["context"]
+                    
+                    # Group by context to match original structure
+                    if context not in contexts_seen:
+                        contexts_seen[context] = {
+                            "title": item["title"],
+                            "paragraphs": [{"context": context, "qas": []}]
+                        }
+                        data["data"].append(contexts_seen[context])
+                    
+                    # Add QA to the appropriate context
+                    qa_entry = {
+                        "question": item["question"],
+                        "answers": [{"text": text} for text in item["answers"]["text"]],
+                        "is_impossible": False,
+                        "id": item["id"]
+                    }
+                    contexts_seen[context]["paragraphs"][0]["qas"].append(qa_entry)
+            
+            print(f"Successfully loaded {len(dataset)} samples from HuggingFace datasets, converted to {len(data['data'])} context groups")
+            
+        except Exception as hf_error:
+            raise Exception(f"Both original URL and HuggingFace fallback failed. "
+                          f"Original error: {e}. HuggingFace error: {hf_error}")
+    
+    # Process data into expected format (same logic as before)
+    total_docs = [p["context"] for d in data["data"] for p in d["paragraphs"]]
+    total_docs = sorted(list(set(total_docs)))
+    total_docs_dict = {c: idx for idx, c in enumerate(total_docs)}
+
+    total_qas = []
+    for d in data["data"]:
+        more_docs = [total_docs_dict[p["context"]] for p in d["paragraphs"]]
+        for p in d["paragraphs"]:
+            for qas in p["qas"]:
+                if not qas["is_impossible"]:
+                    total_qas.append(
+                        {
+                            "query": qas["question"],
+                            "outputs": [a["text"] for a in qas["answers"]],
+                            "context": [total_docs_dict[p["context"]]],
+                            "more_context": [
+                                idx
+                                for idx in more_docs
+                                if idx != total_docs_dict[p["context"]]
+                            ],
+                        }
+                    )
+
+    return total_qas, total_docs
+
+
+@cache
+def read_hotpotqa(
+    url="http://curtis.ml.cmu.edu/datasets/hotpot/hotpot_dev_distractor_v1.json",
+) -> tuple[list[dict], list[str]]:
+    """
+    Read HotpotQA dataset with fallback to HuggingFace datasets for CI environments.
+    
+    First attempts to download from the original CMU URL. If that fails (e.g., due to
+    network restrictions in CI), falls back to loading from HuggingFace datasets.
+    """
+    try:
+        # Try original URL first
+        data = download_json(url)
+        print(f"Successfully loaded HotpotQA from original URL: {url}")
+    except Exception as e:
+        print(f"Failed to download HotpotQA from original URL ({e}), falling back to HuggingFace datasets")
+        
+        try:
+            # Fallback to HuggingFace datasets
+            dataset = datasets.load_dataset("hotpot_qa", "distractor", split="validation")
+            
+            # Convert HuggingFace dataset to expected format
+            data = []
+            for item in dataset:
+                # HuggingFace format: context = {'title': [...], 'sentences': [[...], [...]]}
+                # Original format: context = [[title, sentences], [title, sentences], ...]
+                context_converted = []
+                titles = item["context"]["title"]
+                sentences = item["context"]["sentences"]
+                
+                for title, sentence_list in zip(titles, sentences):
+                    context_converted.append([title, sentence_list])
+                
+                data.append({
+                    "id": item["id"],
+                    "question": item["question"],
+                    "answer": item["answer"],
+                    "supporting_facts": item["supporting_facts"],
+                    "context": context_converted
+                })
+            
+            print(f"Successfully loaded {len(data)} samples from HuggingFace datasets")
+            
+        except Exception as hf_error:
+            raise Exception(f"Both original URL and HuggingFace fallback failed. "
+                          f"Original error: {e}. HuggingFace error: {hf_error}")
+    
+    # Process data into expected format (same logic as before)
+    total_docs = [f"{t}\n{''.join(p)}" for d in data for t, p in d["context"]]
+    total_docs = sorted(list(set(total_docs)))
+    total_docs_dict = {c: idx for idx, c in enumerate(total_docs)}
+
+    total_qas = []
+    for d in data:
+        total_qas.append(
+            {
+                "query": d["question"],
+                "outputs": [d["answer"]],
+                "context": [
+                    total_docs_dict[f"{t}\n{''.join(p)}"] for t, p in d["context"]
+                ],
+            }
+        )
+
+    return total_qas, total_docs
+
+
+def generate_input_output(
+    index: int, num_docs: int, qas: list[dict], docs: list[str]
+) -> tuple[str, list[str]]:
+    curr_q: str = qas[index]["query"]
+    curr_a: list[str] = qas[index]["outputs"]
+    curr_docs: list[int] = qas[index]["context"]
+    curr_more: list[int] = qas[index].get("more_context", [])
+    if num_docs < len(docs):
+        if (num_docs - len(curr_docs)) > len(curr_more):
+            addition_docs = [
+                i for i, d in enumerate(docs) if i not in curr_docs + curr_more
+            ]
+            all_docs = (
+                curr_docs
+                + curr_more
+                + random.sample(
+                    addition_docs, max(0, num_docs - len(curr_docs) - len(curr_more))
+                )
+            )
+        else:
+            all_docs = curr_docs + random.sample(curr_more, num_docs - len(curr_docs))
+
+        all_docs = [docs[idx] for idx in all_docs]
+    else:
+        all_docs = docs
+
+    random.Random(SEED).shuffle(all_docs)
+
+    context = "\n\n".join(
+        [DOCUMENT_PROMPT.format(i=i + 1, document=d) for i, d in enumerate(all_docs)]
+    )
+    input_text = TEMPLATE.format(context=context, query=curr_q)
+    return input_text, curr_a
+
+
+def generate_samples(
+    tokenizer,
+    docs: list[str],
+    qas: list[dict],
+    max_seq_length: int,
+    num_samples: int = 500,
+    tokens_to_generate: int = 32,
+    pre_samples: int = 0,
+    incremental: int = 10,
+    remove_newline_tab=False,
+) -> list[dict]:
+    write_jsons = []
+    tokens_to_generate = tokens_to_generate
+
+    # Find the perfect num_docs
+    num_docs = incremental
+
+    total_tokens = 0  # Track the total tokens generated for this example
+    while total_tokens + tokens_to_generate < max_seq_length:
+        input_text, answer = generate_input_output(0, num_docs, qas=qas, docs=docs)
+        # Calculate the number of tokens in the example
+        total_tokens = len(tokenizer(input_text + f" {answer}").input_ids)
+        # print(
+        #     f"Max length {max_seq_length} | Current length {total_tokens + tokens_to_generate} | Docs: {num_docs}"
+        # )
+        if total_tokens + tokens_to_generate > max_seq_length:
+            num_docs -= incremental
+            break
+
+        num_docs += incremental
+        if num_docs > len(docs):
+            num_docs = len(docs)
+            break
+    # print("Number of documents:", num_docs)
+
+    # Generate samples
+    for index in tqdm(
+        range(num_samples), desc=f"Generating QA Samples | {max_seq_length}"
+    ):
+        used_docs = num_docs
+        while True:
+            try:
+                input_text, answer = generate_input_output(
+                    index + pre_samples, used_docs, qas=qas, docs=docs
+                )
+                length = len(tokenizer(input_text).input_ids) + tokens_to_generate
+                assert length <= max_seq_length, f"{length} exceeds max_seq_length."
+                break
+            except:  # noqa: E722
+                if used_docs > incremental:
+                    used_docs -= incremental
+
+        if remove_newline_tab:
+            input_text = " ".join(
+                input_text.replace("\n", " ").replace("\t", " ").strip().split()
+            )
+
+        formatted_output = {
+            "index": index,
+            "input": input_text,
+            "outputs": answer,
+            "length": length,
+            "max_length": max_seq_length,
+            "gen_prefix": "Answer:",
+        }
+        write_jsons.append(formatted_output)
+
+    return write_jsons
+
+
+def get_dataset(pretrained, docs, qas, max_seq_length=None, num_samples=500, **kwargs) -> list[dict]:
+    tokenizer = get_tokenizer(pretrained)
+    write_jsons = generate_samples(
+        tokenizer=tokenizer,
+        docs=docs,
+        qas=qas,
+        num_samples=num_samples,
+        tokens_to_generate=32,
+        max_seq_length=max_seq_length,
+    )
+    return write_jsons
+
+
+def get_qa_dataset(ds, **kwargs) -> dict[str, datasets.Dataset]:
+    pretrained = kwargs.get("tokenizer", kwargs.get("pretrained", {}))
+    base_samples = kwargs.pop("num_samples_per_length", 500)  # Base sample count
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)  # Apply limit per sequence length
+    if ds == "squad":
+        qas, docs = read_squad()
+    else:
+        qas, docs = read_hotpotqa()
+    df = (
+        get_dataset(pretrained=pretrained, docs=docs, qas=qas, max_seq_length=seq, num_samples=num_samples)
+        for seq in kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    )
+
+    return {
+        "test": datasets.Dataset.from_list(
+            list(itertools.chain.from_iterable(df)), split=datasets.Split.TEST
+        )
+    }
+
+
+def get_squad(**kwargs):
+    return get_qa_dataset("squad", **kwargs)
+
+
+def get_hotpotqa(**kwargs):
+    return get_qa_dataset("hotpotqa", **kwargs)

--- a/lm_eval/tasks/ruler_long/qa_utils.py
+++ b/lm_eval/tasks/ruler_long/qa_utils.py
@@ -21,7 +21,7 @@ import datasets
 import requests
 from tqdm import tqdm
 
-from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
+from lm_eval.tasks.ruler_long.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
 
 CONFIG = {
     "tokens_to_generate": 32,

--- a/lm_eval/tasks/ruler_long/ruler.yaml
+++ b/lm_eval/tasks/ruler_long/ruler.yaml
@@ -1,0 +1,30 @@
+group: ruler
+task:
+  - niah_single_1
+  # - niah_single_2
+  # - niah_single_3
+  - niah_multikey_1
+  # - niah_multikey_2
+  # - niah_multikey_3
+  - niah_multiquery
+  # - niah_multivalue
+  - ruler_vt
+  - ruler_cwe
+  - ruler_fwe
+  - ruler_qa_squad
+  # - ruler_qa_hotpot
+aggregate_metric_list:
+  - metric: "4096"
+    weight_by_size: False
+  - metric: "8192"
+    weight_by_size: False
+  - metric: "16384"
+    weight_by_size: False
+  - metric: "32768"
+    weight_by_size: False
+  - metric: "65536"
+    weight_by_size: False
+  - metric: "131072"
+    weight_by_size: False
+metadata:
+  version: 1

--- a/lm_eval/tasks/ruler_long/ruler_long.yaml
+++ b/lm_eval/tasks/ruler_long/ruler_long.yaml
@@ -1,4 +1,4 @@
-group: ruler
+group: ruler_long
 task:
   - niah_single_1
   # - niah_single_2

--- a/lm_eval/tasks/ruler_long/vt.yaml
+++ b/lm_eval/tasks/ruler_long/vt.yaml
@@ -1,0 +1,9 @@
+include: niah_single_1.yaml
+task: ruler_vt
+custom_dataset: !function vt_utils.get_vt_dataset
+target_delimiter: "\n\n"
+generation_kwargs:
+  do_sample: false
+  temperature: 0.0
+  max_gen_toks: 30
+  until: []

--- a/lm_eval/tasks/ruler_long/vt_utils.py
+++ b/lm_eval/tasks/ruler_long/vt_utils.py
@@ -23,7 +23,7 @@ import datasets
 import numpy as np
 from tqdm import tqdm
 
-from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
+from lm_eval.tasks.ruler_long.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
 
 
 if TYPE_CHECKING:

--- a/lm_eval/tasks/ruler_long/vt_utils.py
+++ b/lm_eval/tasks/ruler_long/vt_utils.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# adapted from https://github.com/NVIDIA/RULER/blob/main/scripts/data/synthetic/variable_tracking.py
+
+import itertools
+import random
+import string
+from typing import TYPE_CHECKING, Union
+
+import datasets
+import numpy as np
+from tqdm import tqdm
+
+from lm_eval.tasks.ruler.common_utils import DEFAULT_SEQ_LENGTHS, get_tokenizer, get_limit_factor
+
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
+CONFIG = {
+    "variable_tracking": {
+        "tokens_to_generate": 30,
+        "template": """Memorize and track the chain(s) of variable assignment hidden in the following text.\n\n{context}\nQuestion: Find all variables that are assigned the value {query} in the text above.""",
+        "answer_prefix": """ Answer: According to the chain(s) of variable assignment in the text above, {num_v} variables are assgined the value {query}, they are: """,
+    },
+}
+
+TEMPLATE = (
+    CONFIG["variable_tracking"]["template"]
+    + CONFIG["variable_tracking"]["answer_prefix"]
+)
+
+
+def generate_chains(
+    num_chains: int, num_hops: int, is_icl: bool = False
+) -> tuple[list[list[str]], list[list[str]]]:
+    vars_all = []
+    k = 5 if not is_icl else 3
+    num_hops = num_hops if not is_icl else min(10, num_hops)
+    vars_all = [
+        "".join(random.choices(string.ascii_uppercase, k=k)).upper()
+        for _ in range((num_hops + 1) * num_chains)
+    ]
+    while len(set(vars_all)) < num_chains * (num_hops + 1):
+        vars_all.append("".join(random.choices(string.ascii_uppercase, k=k)).upper())
+
+    vars_ret = []
+    chains_ret = []
+    for i in range(0, len(vars_all), num_hops + 1):
+        this_vars = vars_all[i : i + num_hops + 1]
+        vars_ret.append(this_vars)
+        this_chain = [f"VAR {this_vars[0]} = {np.random.randint(10000, 99999)}"]
+        for j in range(num_hops):
+            this_chain.append(f"VAR {this_vars[j + 1]} = VAR {this_vars[j]} ")
+        chains_ret.append(this_chain)
+    return vars_ret, chains_ret
+
+
+def generate_input_output(num_noises, num_chains, num_hops, is_icl=False):
+    vars, chains = generate_chains(num_chains, num_hops, is_icl=is_icl)
+
+    noise = "The grass is green. The sky is blue. The sun is yellow. Here we go. There and back again.\n"
+
+    # Create a list of the repeated noise
+    sentences = [noise] * num_noises
+    if len(sentences) <= len(chains[0]):
+        sentences = [
+            n + "." if len(n.strip()) > 0 else n
+            for n in [x for noise in sentences for x in noise.split(".")]
+        ]
+        try:
+            assert len(sentences) > len(chains[0]), (
+                "Noises too short, unable to generate data"
+            )
+        except:  # noqa: E722
+            print("reduces chain length for not enough noises")
+            chains = [chain[: len(sentences) - 1] for chain in chains]
+    # sample random positions to insert variable assignment
+    for chain_i in chains:
+        # sample random positions (sorted) to insert variable assignment
+        positions = list(sorted(random.sample(range(len(sentences)), len(chain_i))))
+        for insert_pi, j in zip(positions, range(len(chain_i))):
+            sentences.insert(insert_pi + j, chain_i[j])
+
+    # Insert the passkey sentence at the random position
+    context = " ".join(sentences)
+    context = context.replace(". \n", ".\n")
+
+    template = TEMPLATE
+    if (
+        is_icl
+        and template
+        != CONFIG["variable_tracking"]["template"]
+        + CONFIG["variable_tracking"]["answer_prefix"]
+    ):
+        # remove model template
+        cutoff = template.index(CONFIG["variable_tracking"]["template"][:20])
+        cutoff_ans = template.index(CONFIG["variable_tracking"]["answer_prefix"][:10])
+        template = (
+            " ".join(template[cutoff:cutoff_ans].split()[:-1]) + template[cutoff_ans:]
+        )
+
+    value = chains[0][0].split("=")[-1].strip()
+    input_text = template.format(context=context, query=value, num_v=num_hops + 1)
+
+    return input_text, vars[0]
+
+
+def randomize_icl(icl_example: str) -> str:
+    icl_tgt_cut = icl_example.index(CONFIG["variable_tracking"]["answer_prefix"][-10:])
+    icl_tgt = icl_example[icl_tgt_cut + 10 :].strip().split()
+    for item in icl_tgt:
+        new_item = "".join(random.choices(string.ascii_uppercase, k=len(item))).upper()
+        icl_example = icl_example.replace(item, new_item)
+    return icl_example
+
+
+def sys_vartrack_w_noise_random(
+    tokenizer,
+    num_samples: int,
+    max_seq_length: int,
+    incremental: int = 10,
+    num_chains: int = 1,
+    num_hops: int = 4,
+    add_fewshot: bool = True,
+    tokens_to_generate=30,
+    icl_example: dict = None,
+    remove_newline_tab=False,
+):
+    write_jsons = []
+    tokens_to_generate = tokens_to_generate
+
+    # Find the perfect num_noises
+    num_noises = incremental
+
+    total_tokens = 0  # Track the total tokens generated for this example
+    example_tokens = 0
+    if add_fewshot and (icl_example is not None):
+        icl_example_out = " ".join(icl_example["outputs"])
+        icl_example = icl_example["input"] + " " + icl_example_out + "\n\n"
+        example_tokens = len(tokenizer(icl_example).input_ids)
+
+    while total_tokens + tokens_to_generate + example_tokens < max_seq_length:
+        input_text, answer = generate_input_output(
+            num_noises, num_chains, num_hops, is_icl=add_fewshot & (icl_example is None)
+        )
+        # Calculate the number of tokens in the example
+        total_tokens = len(tokenizer(input_text + f" {answer}").input_ids)
+        print(
+            f"Max length {max_seq_length} | Current length {total_tokens + tokens_to_generate + example_tokens} | Noises: {num_noises}"
+        )
+        if total_tokens + tokens_to_generate + example_tokens > max_seq_length:
+            num_noises -= incremental
+            break
+        num_noises += incremental
+    print("Num noises:", num_noises)
+
+    # Generate samples
+    for index in tqdm(range(num_samples)):
+        used_noises = num_noises
+        while True:
+            try:
+                input_text, answer = generate_input_output(
+                    used_noises,
+                    num_chains,
+                    num_hops,
+                    is_icl=add_fewshot & (icl_example is None),
+                )
+                length = (
+                    len(tokenizer(input_text).input_ids)
+                    + tokens_to_generate
+                    + example_tokens
+                )
+                assert length <= max_seq_length, f"{length} exceeds max_seq_length."
+                break
+            except:  # noqa: E722
+                if used_noises > incremental:
+                    used_noises -= incremental
+
+        if add_fewshot and (icl_example is not None):
+            # insert icl_example between model template and input
+            cutoff = input_text.index(CONFIG["variable_tracking"]["template"][:20])
+            input_text = (
+                input_text[:cutoff]
+                + randomize_icl(icl_example)
+                + "\n\n"
+                + input_text[cutoff:]
+            )
+        if remove_newline_tab:
+            input_text = " ".join(
+                input_text.replace("\n", " ").replace("\t", " ").strip().split()
+            )
+
+        gen_prefix_index = input_text.rfind(
+            " Answer: According to the chain(s) of variable assignment"
+        )
+        gen_prefix = input_text[gen_prefix_index:].strip()
+        # This condition is to check if we are generating the few-shot.
+        if icl_example is not None:
+            input_text = input_text[:gen_prefix_index]
+        formatted_output = {
+            "index": index,
+            "input": input_text,
+            "outputs": answer,
+            "length": length,
+            "max_length": max_seq_length,
+            "gen_prefix": gen_prefix.strip(),
+        }
+        write_jsons.append(formatted_output)
+
+    return write_jsons
+
+
+def get_dataset(
+    tokenizer: Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"],
+    seq=None,
+    num_samples=500,
+    **kwargs,
+) -> list[dict]:
+    icl_example = sys_vartrack_w_noise_random(
+        tokenizer=tokenizer,
+        num_samples=1,
+        max_seq_length=500,
+        incremental=5,
+    )[0]
+    write_jsons = sys_vartrack_w_noise_random(
+        tokenizer=tokenizer,
+        num_samples=num_samples,
+        max_seq_length=seq,
+        icl_example=icl_example,
+    )
+    return write_jsons
+
+
+def get_vt_dataset(**kwargs) -> dict[str, datasets.Dataset]:
+    pretrained = kwargs.get("tokenizer", kwargs.get("pretrained", ""))
+    base_samples = kwargs.pop("num_samples_per_length", 500)  # Base sample count
+    limit_factor = get_limit_factor(kwargs)
+    num_samples = int(base_samples * limit_factor)  # Apply limit per sequence length
+    df = (
+        get_dataset(tokenizer=get_tokenizer(pretrained), seq=seq, num_samples=num_samples)
+        for seq in kwargs.pop("max_seq_lengths", DEFAULT_SEQ_LENGTHS)
+    )
+
+    return {
+        "test": datasets.Dataset.from_list(
+            list(itertools.chain.from_iterable(df)), split=datasets.Split.TEST
+        )
+    }


### PR DESCRIPTION
## Problem
The N300 runs out of memory when evaluating 128K context sequences in RULER, preventing long-context validation on larger hardware like T3K that can support these lengths.

## Solution
Create separate `ruler_long` task to enable 128K context testing without breaking N300 evals:
- ruler: Tests up to 65K tokens (N300 compatible)
- ruler_long: Tests up to 128K tokens (T3K and Galaxy)
This allows flexible hardware-specific eval configurations while maintaining full long-context coverage where supported.

### Note
Kept the same 7/13 subtasks as `ruler` for consistency. 