### PR TITLE
Update longbench max token len

### DIFF
--- a/lm_eval/tasks/longbench/lcc_e.yaml
+++ b/lm_eval/tasks/longbench/lcc_e.yaml
@@ -10,7 +10,7 @@ doc_to_text: "Please complete the code given below. \n{{context}}Next line of co
 doc_to_target: '{{answers}}'
 process_results: !function metrics.get_code_sim_with_score
 generation_kwargs:
-  max_gen_toks: 64
+  max_gen_toks: 512
   temperature: 1
   do_sample: False
   until: []

--- a/lm_eval/tasks/longbench/repobench-p_e.yaml
+++ b/lm_eval/tasks/longbench/repobench-p_e.yaml
@@ -10,7 +10,7 @@ doc_to_text: "Please complete the code given below. \n{{context}}{{question}}Nex
 doc_to_target: '{{answers}}'
 process_results: !function metrics.get_code_sim_with_score
 generation_kwargs:
-  max_gen_toks: 64
+  max_gen_toks: 512
   temperature: 1
   do_sample: False
   until: []

--- a/lm_eval/tasks/longbench/samsum_e.yaml
+++ b/lm_eval/tasks/longbench/samsum_e.yaml
@@ -11,7 +11,7 @@ doc_to_target: '{{answers}}'
 target_delimiter: ""
 process_results: !function metrics.get_rouge_with_score
 generation_kwargs:
-  max_gen_toks: 128
+  max_gen_toks: 512
   temperature: 1
   do_sample: False
   until: ["\n"]

--- a/lm_eval/tasks/longbench/trec_e.yaml
+++ b/lm_eval/tasks/longbench/trec_e.yaml
@@ -11,7 +11,7 @@ doc_to_target: '{{answers}}'
 target_delimiter: ""
 process_results: !function metrics.get_classification_with_score
 generation_kwargs:
-  max_gen_toks: 64
+  max_gen_toks: 512
   temperature: 1
   do_sample: False
   until: ["\n"]

--- a/lm_eval/tasks/longbench/triviaqa_e.yaml
+++ b/lm_eval/tasks/longbench/triviaqa_e.yaml
@@ -11,7 +11,7 @@ target_delimiter: ""
 doc_to_target: '{{answers}}'
 process_results: !function metrics.get_qa_f1_with_score
 generation_kwargs:
-  max_gen_toks: 32
+  max_gen_toks: 512
   temperature: 1
   do_sample: False
   until: ["\n"]


### PR DESCRIPTION
I changed max-token-len to 512 to match the set up on used on A100

> local-completions ({'model': 'meta-llama/Llama-3.1-8B-Instruct', 'base_url': 'http://127.0.0.1:8000/v1/completions', 'tokenizer_backend': 'huggingface'}), gen_kwargs: ({'temperature': 0, '**max_gen_toks': 512**}), limit: None, num_fewshot: None, batch_size: 1