### PR TITLE
Modify prompt to guide answer to regex-friendly format

### DIFF
--- a/lm_eval/tasks/mmlu/generative/_default_template_yaml
+++ b/lm_eval/tasks/mmlu/generative/_default_template_yaml
@@ -35,6 +35,5 @@ filter_list:
         # [\s\S]* greedily matches all characters and newlines.
         # \b([A-D])\b looks for the last standalone A, B, C, or D.
         regex_pattern: "[\\s\\S]*\\b([A-D])\\b"
-        group: 1
 metadata:
   version: 3.0

--- a/lm_eval/tasks/mmlu/generative/_default_template_yaml
+++ b/lm_eval/tasks/mmlu/generative/_default_template_yaml
@@ -32,8 +32,6 @@ filter_list:
   - name: get_response
     filter:
       - function: "regex"
-        # [\s\S]* greedily matches all characters and newlines.
-        # \b([A-D])\b looks for the last standalone A, B, C, or D.
-        regex_pattern: "[\\s\\S]*\\b([A-D])\\b"
+        regex_pattern: ".*\\b([A-D])\\b"
 metadata:
   version: 3.0

--- a/lm_eval/tasks/mmlu/generative/_default_template_yaml
+++ b/lm_eval/tasks/mmlu/generative/_default_template_yaml
@@ -16,17 +16,25 @@ metric_list:
     higher_is_better: true
     ignore_punctuation: true
     ignore_case: true
+# filter_list:
+#   - name: get_response
+#     filter:
+#       # Filter everything after the first break line
+#       - function: "regex"
+#         regex_pattern: "^(.*?)(?=\\n|$)"
+#       # Remove leading white spaces
+#       - function: remove_whitespace
+#       # function to ignore right white spaces or line breaks
+#       - function: "regex"
+#         regex_pattern: "^(.*?)\\s*$"
+#       - function: take_first
 filter_list:
   - name: get_response
     filter:
-      # Filter everything after the first break line
       - function: "regex"
-        regex_pattern: "^(.*?)(?=\\n|$)"
-      # Remove leading white spaces
-      - function: remove_whitespace
-      # function to ignore right white spaces or line breaks
-      - function: "regex"
-        regex_pattern: "^(.*?)\\s*$"
-      - function: take_first
+        # [\s\S]* greedily matches all characters and newlines.
+        # \b([A-D])\b looks for the last standalone A, B, C, or D.
+        regex_pattern: "[\\s\\S]*\\b([A-D])\\b"
+        group: 1
 metadata:
   version: 3.0

--- a/lm_eval/tasks/mmlu/generative/_default_template_yaml
+++ b/lm_eval/tasks/mmlu/generative/_default_template_yaml
@@ -4,7 +4,7 @@ fewshot_split: dev
 fewshot_config:
   sampler: first_n
 output_type: generate_until
-doc_to_text: "{{question.strip()}}\nA. {{choices[0]}}\nB. {{choices[1]}}\nC. {{choices[2]}}\nD. {{choices[3]}}\nAnswer:"
+doc_to_text: "{{question.strip()}}\nA. {{choices[0]}}\nB. {{choices[1]}}\nC. {{choices[2]}}\nD. {{choices[3]}}\nExpress your final answer as the corresponding option 'A', 'B', 'C', or 'D':"
 doc_to_target: "{{['A', 'B', 'C', 'D'][answer]}}"
 generation_kwargs:
   until:
@@ -16,22 +16,23 @@ metric_list:
     higher_is_better: true
     ignore_punctuation: true
     ignore_case: true
-# filter_list:
-#   - name: get_response
-#     filter:
-#       # Filter everything after the first break line
-#       - function: "regex"
-#         regex_pattern: "^(.*?)(?=\\n|$)"
-#       # Remove leading white spaces
-#       - function: remove_whitespace
-#       # function to ignore right white spaces or line breaks
-#       - function: "regex"
-#         regex_pattern: "^(.*?)\\s*$"
-#       - function: take_first
 filter_list:
   - name: get_response
     filter:
+      # Filter everything after the first break line
       - function: "regex"
-        regex_pattern: ".*\\b([A-D])\\b"
+        regex_pattern: "^(.*?)(?=\\n|$)"
+      # Remove leading white spaces
+      - function: remove_whitespace
+      # function to ignore right white spaces or line breaks
+      - function: "regex"
+        regex_pattern: "^(.*?)\\s*$"
+      - function: take_first
+# filter_list:
+#   - name: get_response
+#     filter:
+#       - function: "regex"
+#         regex_pattern: ".*\\b([A-D])\\b"
+#       - function: take_first
 metadata:
   version: 3.0

--- a/lm_eval/tasks/mmlu/generative/_default_template_yaml
+++ b/lm_eval/tasks/mmlu/generative/_default_template_yaml
@@ -28,11 +28,5 @@ filter_list:
       - function: "regex"
         regex_pattern: "^(.*?)\\s*$"
       - function: take_first
-# filter_list:
-#   - name: get_response
-#     filter:
-#       - function: "regex"
-#         regex_pattern: ".*\\b([A-D])\\b"
-#       - function: take_first
 metadata:
   version: 3.0


### PR DESCRIPTION
The previous pattern expects a single letter to be returned like: `A` `B` `C` `D`.

This PR modifies the prompt template to encourage the model to answer with a single character