### PR TITLE
Save partial sample logs on evaluation failure for debugging

### DIFF
--- a/lm_eval/_cli/run.py
+++ b/lm_eval/_cli/run.py
@@ -466,3 +466,24 @@ class Run(SubCommand):
 
             if cfg.wandb_args:
                 wandb_logger.run.finish()
+
+            if cfg.log_samples:
+                sentinel_count = 0
+                for task_samples in samples.values():
+                    for sample in task_samples:
+                        for resp_group in sample.get("resps", []):
+                            for resp in resp_group:
+                                if isinstance(resp, str) and (
+                                    "__INFERENCE_ERROR__" in resp
+                                    or "__PARTIAL_OUTPUT__" in resp
+                                ):
+                                    sentinel_count += 1
+                if sentinel_count > 0:
+                    eval_logger.error(
+                        f"{sentinel_count} prompt(s) failed during inference. "
+                        "Sample logs have been saved for debugging."
+                    )
+                    raise RuntimeError(
+                        f"Evaluation completed with {sentinel_count} failed prompt(s). "
+                        "Check samples_*.jsonl for __INFERENCE_ERROR__ and __PARTIAL_OUTPUT__ entries."
+                    )

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -509,6 +509,7 @@ class TemplateAPI(TemplateLM):
             **kwargs,
         )
         cache_method = "generate_until" if generate else "loglikelihood"
+        is_streaming = generate and str(payload.get("stream", False)).lower() == "true"
         acquired = await sem.acquire()
         try:
             async with session.post(
@@ -524,7 +525,12 @@ class TemplateAPI(TemplateLM):
                     )
                 # raising exception will retry the request
                 response.raise_for_status()
-                outputs = await response.json()
+
+                if is_streaming:
+                    outputs = await self._consume_sse_stream(response)
+                else:
+                    outputs = await response.json()
+
             answers = (
                 self.parse_generations(
                     outputs=outputs,
@@ -548,6 +554,59 @@ class TemplateAPI(TemplateLM):
         finally:
             if acquired:
                 sem.release()
+
+    async def _consume_sse_stream(self, response) -> dict:
+        """Read an SSE stream and return a dict matching the non-streaming
+        response format ({"choices": [{"index": i, "text": full_text}, ...]}).
+
+        If an error interrupts the stream after tokens have been received,
+        returns a synthetic response whose text is prefixed with
+        ``__PARTIAL_OUTPUT__`` so callers can identify incomplete generations.
+        """
+        accumulated: Dict[int, str] = {}
+        try:
+            while True:
+                line_bytes = await response.content.readline()
+                if not line_bytes:
+                    break
+                line = line_bytes.decode("utf-8").strip()
+                if not line or not line.startswith("data:"):
+                    continue
+                data = line[len("data:"):].strip()
+                if data == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data)
+                    for choice in chunk.get("choices", []):
+                        idx = choice.get("index", 0)
+                        text = choice.get("text", "")
+                        accumulated[idx] = accumulated.get(idx, "") + text
+                except json.JSONDecodeError:
+                    continue
+        except BaseException as e:
+            if accumulated:
+                eval_logger.warning(
+                    f"Streaming interrupted ({repr(e)}). "
+                    f"Returning partial output for {len(accumulated)} choice(s)."
+                )
+                max_idx = max(accumulated.keys())
+                return {
+                    "choices": [
+                        {
+                            "index": i,
+                            "text": f"__PARTIAL_OUTPUT__ ({repr(e)}): "
+                            f"{accumulated.get(i, '')}",
+                        }
+                        for i in range(max_idx + 1)
+                    ]
+                }
+            raise
+
+        return {
+            "choices": [
+                {"index": i, "text": t} for i, t in sorted(accumulated.items())
+            ]
+        }
 
     def batch_loglikelihood_requests(
         self, chunks: Iterable[List[LogLikelihoodInputs]]

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -595,7 +595,9 @@ class TemplateAPI(TemplateLM):
                     f"Retry attempt {retry_state.attempt_number}"
                 ),
             )(self.amodel_call)
-            # Create tasks for each batch of request
+            request_batches = list(chunks(requests, n=self._batch_size))
+            cache_key_batches = list(chunks(cache_keys, n=self._batch_size))
+            ctxlen_batches = list(chunks(ctxlens, n=self._batch_size))
             tasks = [
                 asyncio.create_task(
                     retry_(
@@ -609,13 +611,46 @@ class TemplateAPI(TemplateLM):
                     )
                 )
                 for message, cache_key, ctxlen in zip(
-                    chunks(requests, n=self._batch_size),
-                    chunks(cache_keys, n=self._batch_size),
-                    chunks(ctxlens, n=self._batch_size),
+                    request_batches,
+                    cache_key_batches,
+                    ctxlen_batches,
                 )
             ]
 
-            return await tqdm_asyncio.gather(*tasks, desc="Requesting API")
+            pbar = tqdm_asyncio(total=len(tasks), desc="Requesting API")
+
+            async def _track(coro):
+                result = await coro
+                pbar.update(1)
+                return result
+
+            results = await asyncio.gather(
+                *[_track(t) for t in tasks], return_exceptions=True
+            )
+            pbar.close()
+
+            num_failed = sum(1 for r in results if isinstance(r, BaseException))
+            if num_failed:
+                eval_logger.error(
+                    f"{num_failed}/{len(results)} request batch(es) failed. "
+                    "Replacing with error sentinels to preserve partial results."
+                )
+
+            processed = []
+            for i, result in enumerate(results):
+                if isinstance(result, BaseException):
+                    batch_size = len(request_batches[i])
+                    if generate:
+                        processed.append(
+                            [f"__INFERENCE_ERROR__: {repr(result)}"] * batch_size
+                        )
+                    else:
+                        processed.append(
+                            [(float("-inf"), False)] * batch_size
+                        )
+                else:
+                    processed.append(result)
+            return processed
 
     def _loglikelihood_tokens(self, requests, **kwargs) -> List[Tuple[float, bool]]:
         assert self.tokenizer is not None, (


### PR DESCRIPTION
## Problem
When running evaluations against an API server, if any request fails (timeout, server crash, etc.), the current behavior:
- **Loses all batch results**: `tqdm_asyncio.gather()` raises on the first failure, discarding every other successful response in the same `gather()` call.
- **Produces no sample logs**: The evaluation is marked `FAILED` and `samples_*.jsonl` files are never written.
- **Provides no visibility into partial generations**: With `stream=false`, the server generates the entire response before sending it. If the client times out, zero tokens are received. We cannot tell whether the model was producing garbage or just needed more time.

## Solution 

Two changes to `lm_eval/models/api_models.py`

1. Preserve successful batch results alongside failures (`get_batched_requests`)

Replace `tqdm_asyncio.gather()` with `asyncio.gather(return_exceptions=True)`. Failed batches are replaced with typed error sentinels while successful batches are preserved:

|Task type | Sentinel value | Behavior|
|-- | -- | --|
|generate_until | "__INFERENCE_ERROR__: <repr(exception)>" | Appears in samples_*.jsonl, easy to grep
loglikelihood | (-inf, False) | Scores as worst-possible without crashing aggregation|

`tqdm_asyncio.gather()` does not support `return_exceptions`, so we use `asyncio.gather()` directly with a manual `tqdm` progress wrapper that provides equivalent progress reporting.

2. Capture partial model output on streaming timeout (`amodel_call` + `_consume_sse_stream`)

Add a new `_consume_sse_stream()` method that reads SSE events line-by-line and accumulates generated text per choice index. When stream=true is set in gen_kwargs:
- On success: Returns the same format as a non-streaming response, i.e., `parse_generations()` works unchanged.
- On error mid-stream (e.g., timeout after receiving some tokens): Returns the accumulated partial text prefixed with `__PARTIAL_OUTPUT__ (<exception>):`. This flows through scoring and appears in `samples_*.jsonl`, showing exactly what the model generated before the failure.
- On error before any data: Re-raises the exception so tenacity retries as normal.

### Changed files
`lm_eval/models/api_models.py` (only file changed):
- `get_batched_requests()`: `asyncio.gather(return_exceptions=True)` + manual tqdm + error sentinel post-processing 
- `amodel_call()`: Detect `stream=true` in payload; delegate to `_consume_sse_stream()` instead of `response.json()`
- `_consume_sse_stream()`: SSE line reader that accumulates tokens and returns partial output on mid-stream errors


## Test plan
- [ ] `generate_until` with `stream=false` where all prompts succeed. Verify identical output to baseline
- [ ] `generate_until` with `stream=true` where all prompts succeed. Verify identical output to non-streaming
- [ ] `generate_until` with `stream=true` where some prompts timeout mid-generation. Verify `__PARTIAL_OUTPUT__` with actual model tokens appears in sample logs
- [ ] `generate_until` with `stream=false` where some prompts fail. Verify `__INFERENCE_ERROR__` sentinels in sample logs
- [ ] loglikelihood where some batches fail. Verify `(-inf, False)` entries do not crash metric aggregation
- [ ] Verify `tqdm` progress bar displays and updates correctly
- [ ] Verify `tenacity` retries still fire for connection failures (before any streaming data is received)


## Use case
Running long evaluations (e.g., GPQA Diamond, MMLU-Pro) against hardware-accelerated inference servers where individual prompts can timeout or the server can crash mid-batch. The partial sample logs let you distinguish between model quality issues (garbage tokens) and infrastructure failures (timeouts, disconnects) without re-running multi-hour evaluations.
